### PR TITLE
Add additional loading methods to Interpreter

### DIFF
--- a/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/include/cling/Interpreter/DynamicLibraryManager.h
@@ -97,7 +97,7 @@ namespace cling {
     /// other error was encountered.
     ///
     LoadLibResult loadLibrary(const std::string& libStem, bool permanent,
-                              bool resolved = false );
+                              bool resolved = false);
 
     void unloadLibrary(llvm::StringRef libStem);
 

--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -569,9 +569,29 @@ namespace cling {
     ///
     std::string lookupFileOrLibrary(llvm::StringRef file);
 
-    ///\brief Loads header file or shared library.
+    ///\brief Loads a shared library.
     ///
     ///\param [in] filename - The file to loaded.
+    ///\param [in] lookup - Whether to try to resolve the filepath
+    ///
+    ///\returns kMoreInputExpected is returned when file could not be found
+    /// otherwise kSuccess or kFailure
+    ///
+    CompilationResult loadLibrary(const std::string& filename,
+                                  bool lookup = true);
+
+    ///\brief Loads header file
+    ///
+    ///\param [in] filename - The file to loaded.
+    ///\param [out] T -  Transaction containing the loaded file.
+    ///\returns result of the compilation.
+    ///
+    CompilationResult loadHeader(const std::string& filename,
+                               Transaction** T = 0);
+
+    ///\brief Loads header file or shared library.
+    ///
+    ///\param [in] filename - The file to be loaded.
     ///\param [in] allowSharedLib - Whether to try to load the file as shared
     ///                             library.
     ///\param [out] T -  Transaction containing the loaded file.

--- a/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/lib/Interpreter/DynamicLibraryManager.cpp
@@ -194,8 +194,8 @@ namespace cling {
   DynamicLibraryManager::LoadLibResult
   DynamicLibraryManager::loadLibrary(const std::string& libStem,
                                      bool permanent, bool resolved) {
-    std::string       lResolved;
-    const std::string &canonicalLoadedLib = resolved ? libStem : lResolved;
+    std::string lResolved;
+    const std::string& canonicalLoadedLib = resolved ? libStem : lResolved;
     if (!resolved) {
       lResolved = lookupLibrary(libStem);
       if (lResolved.empty())

--- a/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/lib/Interpreter/DynamicLibraryManager.cpp
@@ -167,12 +167,8 @@ namespace cling {
 
   std::string
   DynamicLibraryManager::lookupLibrary(llvm::StringRef libStem) const {
-    llvm::SmallString<128> Absolute(libStem);
-    llvm::sys::fs::make_absolute(Absolute);
-    bool isAbsolute = libStem == Absolute;
-
     // If it is an absolute path, don't try iterate over the paths.
-    if (isAbsolute) {
+    if (llvm::sys::path::is_absolute(libStem)) {
       if (isSharedLib(libStem))
         return normalizePath(libStem);
       else

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -1159,13 +1159,15 @@ namespace cling {
   }
 
   Interpreter::CompilationResult
-  Interpreter::loadFile(const std::string& filename,
-                        bool allowSharedLib /*=true*/,
-                        Transaction** T /*= 0*/) {
+  Interpreter::loadLibrary(const std::string& filename, bool lookup) {
     DynamicLibraryManager* DLM = getDynamicLibraryManager();
-    std::string canonicalLib = DLM->lookupLibrary(filename);
-    if (allowSharedLib && !canonicalLib.empty()) {
-      switch (DLM->loadLibrary(canonicalLib, /*permanent*/false, /*resolved*/true)) {
+    std::string canonicalLib;
+    if (lookup)
+      canonicalLib = DLM->lookupLibrary(filename);
+
+    const std::string &library = lookup ? canonicalLib : filename;
+    if (!library.empty()) {
+      switch (DLM->loadLibrary(library, /*permanent*/false, /*resolved*/true)) {
       case DynamicLibraryManager::kLoadLibSuccess: // Intentional fall through
       case DynamicLibraryManager::kLoadLibAlreadyLoaded:
         return kSuccess;
@@ -1177,7 +1179,12 @@ namespace cling {
         return kFailure;
       }
     }
+    return kMoreInputExpected;
+  }
 
+  Interpreter::CompilationResult
+  Interpreter::loadHeader(const std::string& filename,
+                          Transaction** T /*= 0*/) {
     std::string code;
     code += "#include \"" + filename + "\"";
 
@@ -1265,6 +1272,18 @@ namespace cling {
       }
       unload(*T);
     }
+  }
+
+  Interpreter::CompilationResult
+  Interpreter::loadFile(const std::string& filename,
+                        bool allowSharedLib /*=true*/,
+                        Transaction** T /*= 0*/) {
+    if (allowSharedLib) {
+      CompilationResult result = loadLibrary(filename, true);
+      if (result!=kMoreInputExpected)
+        return result;
+    }
+    return loadHeader(filename, T);
   }
 
   static void runAndRemoveStaticDestructorsImpl(IncrementalExecutor &executor,


### PR DESCRIPTION
Add additional `Interpreter::loadLibrary` and `Interpreter::loadHeader` calls and have `Interpreter::loadFile` call though to those.

This is mostly in preparation for 1 (maybe 2) more PR than needs to occur before print unloading can work.
They are pretty trivial and the other(s) less so.