### PR TITLE
All Decl Unloading

### DIFF
--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -384,15 +384,22 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
   static SourceLocation getDeclLocation(Decl* D) {
     switch (D->getKind()) {
       case Decl::ClassTemplateSpecialization:
-      case Decl::ClassTemplatePartialSpecialization:
-        return cast<ClassTemplateSpecializationDecl>(D)->getPointOfInstantiation();
+      case Decl::ClassTemplatePartialSpecialization: {
+        const SourceLocation Loc = cast<ClassTemplateSpecializationDecl>(D)->getPointOfInstantiation();
+        if (Loc.isValid())
+          return Loc;
+        break;
+      }
       case Decl::Function: {
           FunctionDecl* FD = cast<FunctionDecl>(D);
           if (FunctionTemplateSpecializationInfo *Info =
                                           FD->getTemplateSpecializationInfo()) {
-            return Info->getPointOfInstantiation();
+            const SourceLocation Loc = Info->getPointOfInstantiation();
+            if (Loc.isValid())
+              return Loc;
           }
-        }
+        break;
+      }
       default:
         break;
     }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -1240,6 +1240,10 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
                                         ClassTemplateSpecializationDecl* CTSD) {
     // ClassTemplateSpecializationDecl: CXXRecordDecl, FoldingSet
 
+    const SourceLocation Loc = CTSD->getPointOfInstantiation();
+    if (m_VisSpecializations && !Loc.isValid())
+      return true;
+
     ClassTemplateSpecializationDecl* CanonCTSD =
       static_cast<ClassTemplateSpecializationDecl*>(CTSD->getCanonicalDecl());
     if (auto D = dyn_cast<ClassTemplatePartialSpecializationDecl>(CanonCTSD))
@@ -1251,8 +1255,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
                                                  CanonCTSD);
 
     bool Success = true;
-    if (m_VisSpecializations ||
-        !wasInstatiatedBefore(CTSD->getPointOfInstantiation())) {
+    if (m_VisSpecializations || !wasInstatiatedBefore(Loc)) {
       VisStateRestore visState(m_VisSpecializations);
       Success = VisitCXXRecordDecl(CTSD);
     }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -589,7 +589,8 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     // llvm::Module cannot contain:
     // * variables and parameters with dependent context;
     // * mangled names for parameters;
-    if (!isa<ParmVarDecl>(VD) && !VD->getDeclContext()->isDependentContext()) {
+    const bool DepContext = VD->getDeclContext()->isDependentContext();
+    if (!isa<ParmVarDecl>(VD) && !DepContext) {
       // Cleanup the module if the transaction was committed and code was
       // generated. This has to go first, because it may need the AST
       // information which we will remove soon. (Eg. mangleDeclName iterates the
@@ -600,7 +601,8 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
 
     // VarDecl : DeclaratiorDecl, Redeclarable
     bool Successful = VisitRedeclarable(VD, VD->getDeclContext());
-    Successful &= VisitDeclaratorDecl(VD);
+    if (!DepContext)
+      Successful &= VisitDeclaratorDecl(VD);
 
     return Successful;
   }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -6,7 +6,7 @@
 // of Illinois Open Source License or the GNU Lesser General Public License. See
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
-
+#define private public  // FIXME: Make DeclUnloader a friend of clang::TagDecl
 #include "DeclUnloader.h"
 
 #include "cling/Utils/AST.h"

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -743,10 +743,12 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     if (NSD->isInline()) {
       NamespaceDecl* Parent = cast<NamespaceDecl>(NSD->getParent());
       do {
-        // Should always have a lookup ptr: NSD is inside of it!
-        assert((Parent->getFirstDecl() != Parent ? !Parent->getLookupPtr() :
-               Parent->getLookupPtr() != nullptr) && "Has unique lookup ptr!");
-        Parents.insert(Parent->getFirstDecl()->getLookupPtr());
+        assert((Parent->getFirstDecl() != Parent ? !Parent->getLookupPtr() : 1)
+               && "Has unique lookup ptr!");
+        // There is a chance that lookup ptr will not exist when rolling back
+        // a bad Transaction. The question is whether we can stop the loop too?
+        if (StoredDeclsMap* Map = Parent->getFirstDecl()->getLookupPtr())
+          Parents.insert(Map);
         DeclContext* Next = Parent->getParent();
         Parent = dyn_cast<NamespaceDecl>(Next);
       } while (Parent);

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -557,8 +557,8 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     // We start with the decl context first, because parameters are part of the
     // DeclContext and when trying to remove them we need the full redecl chain
     // still in place.
-    bool Successful = VisitDeclContext(FD);
-    Successful &= VisitRedeclarable(FD, FD->getDeclContext());
+    bool Successful = VisitRedeclarable(FD, FD->getDeclContext());
+    Successful &= VisitDeclContext(FD);
     Successful &= VisitDeclaratorDecl(FD);
 
     // Template instantiation of templated function first creates a canonical
@@ -711,8 +711,8 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
 
   bool DeclUnloader::VisitNamespaceDecl(NamespaceDecl* NSD) {
     // NamespaceDecl: NamedDecl, DeclContext, Redeclarable
-    bool Successful = VisitDeclContext(NSD);
-    Successful &= VisitRedeclarable(NSD, NSD->getDeclContext());
+    bool Successful = VisitRedeclarable(NSD, NSD->getDeclContext());
+    Successful &= VisitDeclContext(NSD);
     Successful &= VisitNamedDecl(NSD);
 
     return Successful;
@@ -809,8 +809,8 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
 
   bool DeclUnloader::VisitTagDecl(TagDecl* TD) {
     // TagDecl: TypeDecl, DeclContext, Redeclarable
-    bool Successful = VisitDeclContext(TD);
-    Successful &= VisitRedeclarable(TD, TD->getDeclContext());
+    bool Successful = VisitRedeclarable(TD, TD->getDeclContext());
+    Successful &= VisitDeclContext(TD);
     Successful &= VisitTypeDecl(TD);
     return Successful;
   }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -1445,12 +1445,14 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
       ClassTemplateDeclExt::removeSpecialization(CTSD->getSpecializedTemplate(),
                                                  CanonCTSD);
 
-    bool Success = true;
-    if (!wasInstatiatedBefore(CTSD->getLocEnd())) {
-      VisitorState VS(*this, kVisitingSpecialization);
-      Success = VisitCXXRecordDecl(CTSD);
-    }
+    if (wasInstatiatedBefore(CTSD->getPointOfInstantiation()))
+      return true;
 
-    return Success;
+    VisitorState VS(*this, kVisitingSpecialization);
+
+    bool Successful = true;
+    Successful &= VisitRedeclarable(CTSD, CTSD->getDeclContext());
+    Successful &= VisitCXXRecordDecl(CTSD);
+    return Successful;
   }
 } // end namespace cling

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -42,6 +42,9 @@ void DeclUnloader::resetDefinitionData(DeclT*) {
 template <>
 void DeclUnloader::resetDefinitionData(clang::TagDecl* D) {
   if (clang::CXXRecordDecl* C = dyn_cast<CXXRecordDecl>(D)) {
+    // It was allocated this way...
+    ::operator delete(C->DefinitionData, D->getASTContext(),
+                      sizeof(CXXRecordDecl::DefinitionData));
     for (C = C->getCanonicalDecl()->getMostRecentDecl(); C;
          C = C->getPreviousDecl()) {
       C->DefinitionData = nullptr;

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -502,13 +502,24 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     return Successful;
   }
 
+  bool DeclUnloader::VisitUsingDecl(UsingDecl* UD) {
+    // UsingDecl: NamedDecl, Mergeable<UsingDecl>
+    bool Success = true;
+    for (UsingShadowDecl *USD : UD->shadows())
+      Success &= VisitUsingShadowDecl(USD);
+
+    // Calling VisitNamedDecl will triger an assert in clang as the decl
+    // has already been removed when the last shadow is gone.
+    // Success &= VisitNamedDecl(UD);
+    return Success;
+  }
+
   bool DeclUnloader::VisitTypedefNameDecl(TypedefNameDecl* TND) {
     // TypedefNameDecl: TypeDecl, Redeclarable
     bool Successful = VisitRedeclarable(TND, TND->getDeclContext());
     Successful &= VisitTypeDecl(TND);
     return Successful;
   }
-
 
   bool DeclUnloader::VisitVarDecl(VarDecl* VD) {
     // llvm::Module cannot contain:

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -376,8 +376,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
       return;
     const SourceManager& SM = m_Sema->getSourceManager();
     FileID FID = SM.getFileID(SM.getSpellingLoc(Loc));
-    if (!FID.isInvalid() && FID >= m_CurTransaction->getBufferFID()
-        && !m_FilesToUncache.count(FID))
+    if (!FID.isInvalid() && FID >= m_CurTransaction->getBufferFID())
       m_FilesToUncache.insert(FID);
   }
 

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -820,11 +820,19 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
       assert(Successful);
 
       if (NamedDecl *ND = dyn_cast<NamedDecl>(*I)) {
-        for (StoredDeclsMap* Parent : Parents) {
-          eraseDeclFromMap(Parent, ND);
-#ifndef NDEBUG
-          checkDeclIsGone(Parent, ND);
-#endif
+        UsingShadowDecl* USD = dyn_cast<UsingShadowDecl>(ND);
+        assert((USD ? USD->getTargetDecl()!=nullptr : 1)
+               && "No target for UsingShadow");
+        const bool Skip = USD &&
+                    wasInstatiatedBefore(getDeclLocation(USD->getTargetDecl()));
+
+        if (!Skip) {
+          for (StoredDeclsMap* Parent : Parents) {
+            eraseDeclFromMap(Parent, ND);
+  #ifndef NDEBUG
+            checkDeclIsGone(Parent, ND);
+  #endif
+          }
         }
       }
     }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -1432,9 +1432,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
                                         ClassTemplateSpecializationDecl* CTSD) {
     // ClassTemplateSpecializationDecl: CXXRecordDecl, FoldingSet
 
-    const bool VisitingSpec = m_Flags & kVisitingSpecialization;
-    const SourceLocation Loc = CTSD->getPointOfInstantiation();
-    if (VisitingSpec && !Loc.isValid())
+    if (m_Flags & kVisitingSpecialization)
       return true;
 
     ClassTemplateSpecializationDecl* CanonCTSD =
@@ -1448,7 +1446,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
                                                  CanonCTSD);
 
     bool Success = true;
-    if (!wasInstatiatedBefore(Loc)) {
+    if (!wasInstatiatedBefore(CTSD->getLocEnd())) {
       VisitorState VS(*this, kVisitingSpecialization);
       Success = VisitCXXRecordDecl(CTSD);
     }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -1417,7 +1417,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
                                                  CanonCTSD);
 
     bool Success = true;
-    if (VisitingSpec || !wasInstatiatedBefore(Loc)) {
+    if (!wasInstatiatedBefore(Loc)) {
       VisitorState VS(*this, kVisitingSpecialization);
       Success = VisitCXXRecordDecl(CTSD);
     }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -26,7 +26,16 @@
 namespace cling {
 using namespace clang;
 
+static SourceLocation getDeclLocation(Decl* D);
+
 bool DeclUnloader::UnloadDecl(Decl* D) {
+  // FIXME: This prune can easily be handled in the Transaction to save memory.
+  // ClassTemplateSpecializationDecl does it's own filtering based on Location.
+  if (!dyn_cast<ClassTemplateSpecializationDecl>(D)) {
+    if (wasInstatiatedBefore(D->getLocEnd()))
+      return true;
+  }
+
   DiagnosticErrorTrap Trap(m_Sema->getDiagnostics());
   const bool Successful = Visit(D);
   if (Trap.hasErrorOccurred())

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -481,11 +481,8 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
       DC = DC->getLookupParent();
 
     // if the decl was anonymous we are done.
-    if (!ND->getIdentifier())
-      return Successful;
-
-     // If the decl was removed make sure that we fix the lookup
-    if (Successful) {
+    if (Successful && ND->getIdentifier()) {
+      // If the decl was removed make sure that we fix the lookup
       if (Scope* S = m_Sema->getScopeForContext(DC))
         S->RemoveDecl(ND);
 

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -31,7 +31,7 @@ static SourceLocation getDeclLocation(Decl* D);
 bool DeclUnloader::UnloadDecl(Decl* D) {
   // FIXME: This prune can easily be handled in the Transaction to save memory.
   // ClassTemplateSpecializationDecl does it's own filtering based on Location.
-  if (!dyn_cast<ClassTemplateSpecializationDecl>(D)) {
+  if (!D->isInvalidDecl()) {
     if (wasInstatiatedBefore(D->getLocEnd()))
       return true;
   }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -536,7 +536,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     bool Successful = true;
     if (DC->containsDecl(D)) {
       llvm::SmallVector<DeclContext*, 4> errors;
-      DC->removeDecl(D, &errors);
+      DC->removeDecl(D/*, &errors*/);
       if (!errors.empty())
         reportErrors(m_Sema, D, Loc, errors);
     }
@@ -1254,7 +1254,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
         GlobalValueEraser GVEraser(m_CodeGen);
         GVEraser.EraseGlobalValue(GV);
       }
-      m_CodeGen->forgetDecl(GD, mangledName);
+      m_CodeGen->forgetDecl(GD/*, mangledName*/);
     }
   }
 

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -634,8 +634,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     bool Successful = true;
     Successful = VisitRedeclarable(USD, USD->getDeclContext());
 
-    if (isOnly && dyn_cast<TypedefNameDecl>(USD->getTargetDecl())) {
-      // It's the last shadow in the chain, of a typedef
+    if (isOnly) {
       // Don't call VisitNamedDecl as it will call eraseDeclFromMap on the
       // primary context, and what it is acually erasing is the UsingDecl.
 
@@ -678,8 +677,12 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
       }
     }
 
-    for (UsingShadowDecl *USD : UD->shadows())
+    llvm::SmallVector<UsingShadowDecl*, 12> Shadows(UD->shadow_begin(),
+                                                    UD->shadow_end());
+    for (UsingShadowDecl *USD : Shadows) {
       Success &= VisitUsingShadowDecl(USD);
+      assert(Success);
+    }
 
     Success &= VisitNamedDecl(UD);
 

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -1254,7 +1254,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
         GlobalValueEraser GVEraser(m_CodeGen);
         GVEraser.EraseGlobalValue(GV);
       }
-      m_CodeGen->forgetDecl(GD);
+      m_CodeGen->forgetDecl(GD, mangledName);
     }
   }
 

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -748,6 +748,33 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     return Successful;
   }
 
+  bool DeclUnloader::VisitFriendDecl(FriendDecl* FD) {
+    // FriendDecl: Decl
+    
+    // Remove the friend declarations
+    bool Successful = true;
+    if (TypeSourceInfo* TI = FD->getFriendType()) {
+      if (const Type* T = TI->getType().getTypePtrOrNull()) {
+        if (const TagType* RT = T->getAs<TagType>()) {
+          TagDecl *F = RT->getDecl();
+          // If the friend is a class and embedded in the parent and not defined
+          // then there is no further declaration so it must be unloaded now.
+          if (F->isEmbeddedInDeclarator() &&  !F->isCompleteDefinition()) {
+            // Avoid recursion: class A { class B { friend class A; } }
+            TagDecl* Parent = dyn_cast_or_null<TagDecl>(FD->getDeclContext());
+            if (!Parent || F != Parent->getDeclContext())
+              Successful &= Visit(F);
+          }
+        }
+      }
+    }
+    else if (NamedDecl* ND = FD->getFriendDecl())
+      Successful &= Visit(ND);
+
+    Successful &= VisitDecl(FD);
+    return Successful;
+  }
+
   bool DeclUnloader::VisitTagDecl(TagDecl* TD) {
     // TagDecl: TypeDecl, DeclContext, Redeclarable
     bool Successful = VisitDeclContext(TD);

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -1441,9 +1441,11 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
       ClassTemplateDeclExt::removePartialSpecialization(
                                                     D->getSpecializedTemplate(),
                                                     D);
-    else
-      ClassTemplateDeclExt::removeSpecialization(CTSD->getSpecializedTemplate(),
-                                                 CanonCTSD);
+    else {
+      ClassTemplateDecl* CTD = CTSD->getSpecializedTemplate();
+      if (!CTD->isThisDeclarationReferenced())
+        ClassTemplateDeclExt::removeSpecialization(CTD, CanonCTSD);
+    }
 
     if (wasInstatiatedBefore(CTSD->getPointOfInstantiation()))
       return true;

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -802,13 +802,10 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
 
   bool DeclUnloader::VisitDeclContext(DeclContext* DC) {
     bool Successful = true;
-    typedef llvm::SmallVector<Decl*, 64> Decls;
-    Decls declsToErase;
+
     // Removing from single-linked list invalidates the iterators.
-    for (DeclContext::decl_iterator I = DC->noload_decls_begin();
-         I != DC->noload_decls_end(); ++I) {
-      declsToErase.push_back(*I);
-    }
+    typedef llvm::SmallVector<Decl*, 64> Decls;
+    Decls declsToErase(DC->noload_decls_begin(), DC->noload_decls_end());
 
     for(Decls::reverse_iterator I = declsToErase.rbegin(),
           E = declsToErase.rend(); I != E; ++I) {

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -324,6 +324,12 @@ namespace cling {
     bool VisitRedeclarable(clang::Redeclarable<T>* R, clang::DeclContext* DC);
 
     bool VisitReturnValue(const clang::QualType T, clang::Decl* Parent);
+    
+    ///\brief Remove the NamedDecl from it's parent scope.
+    ///\param[in] force - Don't check if the decl is anonymous.
+    ///\returns The lookup context for the decl.
+    ///
+    clang::DeclContext* removeFromScope(clang::NamedDecl* ND, bool Force = false);
   };
 
   /// \brief Unload a Decl from the AST, but not from CodeGen or Module.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -304,21 +304,11 @@ namespace cling {
     template <class DeclT>
     bool VisitSpecializations(DeclT *D);
 
-    LLVM_CONSTEXPR static bool isDefinition(void*) { return false; }
-    static bool isDefinition(clang::TagDecl* R);
-
-    static void resetDefinitionData(void*) {
-      llvm_unreachable("resetDefinitionData on non-cxx record declaration");
-    }
-
-    static void resetDefinitionData(clang::TagDecl *decl);
+    template<typename DeclT>
+    static void resetDefinitionData(DeclT* R);
 
     template<typename DeclT>
     static void removeRedeclFromChain(DeclT* R);
-
-    static void removeRedeclFromChain(void*) {
-      llvm_unreachable("setLatestDeclImpl on non-redeclarable declaration");
-    }
 
     template <typename T>
     bool VisitRedeclarable(clang::Redeclarable<T>* R, clang::DeclContext* DC);

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -64,7 +64,7 @@ namespace cling {
     ///\param[in] D - The declaration to forward.
     ///\returns true on success.
     ///
-    bool UnloadDecl(clang::Decl* D) { return Visit(D); }
+    bool UnloadDecl(clang::Decl* D);
 
     ///\brief If it falls back in the base class just remove the declaration
     /// only from the declaration context.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -322,6 +322,8 @@ namespace cling {
 
     template <typename T>
     bool VisitRedeclarable(clang::Redeclarable<T>* R, clang::DeclContext* DC);
+
+    bool VisitReturnValue(const clang::QualType T, clang::Decl* Parent);
   };
 
   /// \brief Unload a Decl from the AST, but not from CodeGen or Module.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -171,6 +171,15 @@ namespace cling {
     ///
     bool VisitLinkageSpecDecl(clang::LinkageSpecDecl* LSD);
 
+    ///\brief Removes all friend named declarations. This is needed
+    /// as under some circumstances clang stores the NamedDecl for a
+    /// friend function in a FriendDecl.
+    /// @param[in] FD - The declaration context to be remove.
+    ///
+    ///\returns true on success.
+    ///
+    bool VisitFriendDecl(clang::FriendDecl* FD);
+
     ///\brief Removes a Tag (class/union/struct/enum). Most of the other
     /// containers fall back into that case.
     /// @param[in] TD - The declaration to be removed.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -49,14 +49,14 @@ namespace cling {
     ///
     FileIDs m_FilesToUncache;
 
-    ///\brief Mark whether we are recursing via VisitSpecializations.
+    ///\brief Mark the current visitation state.
     ///
-    bool m_VisSpecializations;
+    unsigned m_Flags : 4;
+    class VisitorState;
 
   public:
     DeclUnloader(clang::Sema* S, clang::CodeGenerator* CG, const Transaction* T)
-      : m_Sema(S), m_CodeGen(CG), m_CurTransaction(T),
-        m_VisSpecializations(false) { }
+      : m_Sema(S), m_CodeGen(CG), m_CurTransaction(T), m_Flags(0) {}
     ~DeclUnloader();
 
     ///\brief Interface with nice name, forwarding to Visit.
@@ -77,11 +77,10 @@ namespace cling {
     ///\brief Removes the declaration from the lookup chains and from the
     /// declaration context.
     /// @param[in] ND - The declaration to be removed.
-    /// @param[in] Flags - Private information about how to handle removal.
     ///
     ///\returns true on success.
     ///
-    bool VisitNamedDecl(clang::NamedDecl* ND, unsigned Flags = 0);
+    bool VisitNamedDecl(clang::NamedDecl* ND);
 
     ///\brief Removes the declaration from Sema's unused decl registry
     /// @param[in] DD - The declaration to be removed.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -80,7 +80,7 @@ namespace cling {
     ///
     ///\returns true on success.
     ///
-    bool VisitNamedDecl(clang::NamedDecl* ND);
+    bool VisitNamedDecl(clang::NamedDecl* ND, bool RemoveFromScopeMap = true);
 
     ///\brief Removes the declaration from Sema's unused decl registry
     /// @param[in] DD - The declaration to be removed.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -49,9 +49,14 @@ namespace cling {
     ///
     FileIDs m_FilesToUncache;
 
+    ///\brief Mark whether we are recursing via VisitSpecializations.
+    ///
+    bool m_VisSpecializations;
+
   public:
     DeclUnloader(clang::Sema* S, clang::CodeGenerator* CG, const Transaction* T)
-      : m_Sema(S), m_CodeGen(CG), m_CurTransaction(T) { }
+      : m_Sema(S), m_CodeGen(CG), m_CurTransaction(T),
+        m_VisSpecializations(false) { }
     ~DeclUnloader();
 
     ///\brief Interface with nice name, forwarding to Visit.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -77,10 +77,11 @@ namespace cling {
     ///\brief Removes the declaration from the lookup chains and from the
     /// declaration context.
     /// @param[in] ND - The declaration to be removed.
+    /// @param[in] Flags - Private information about how to handle removal.
     ///
     ///\returns true on success.
     ///
-    bool VisitNamedDecl(clang::NamedDecl* ND, bool RemoveFromScopeMap = true);
+    bool VisitNamedDecl(clang::NamedDecl* ND, unsigned Flags = 0);
 
     ///\brief Removes the declaration from Sema's unused decl registry
     /// @param[in] DD - The declaration to be removed.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -287,13 +287,14 @@ namespace cling {
     void CollectFilesToUncache(clang::SourceLocation Loc);
 
     ///\brief Test if the given SourceLocation came before the SourceLocation
-    /// of our Transaction.  If m_CurTransaction is NULL it is assumed to be
-    /// known that the declaration occured in the current Transaction.
+    /// of our Transaction.  If m_CurTransaction is NULL or has an invalid
+    /// source location, it is assumed to be known that the declaration occured
+    /// in the current Transaction.
     ///
     /// This is used to test whether the declaration holding specializations
     /// was actullay part of the transaction being unloaded.
     ///
-    bool wasInstatiatedBefore(clang::Decl *D, const clang::SourceLocation &Loc) const;
+    bool wasInstatiatedBefore(clang::SourceLocation Loc) const;
 
     template <class DeclT>
     bool VisitSpecializations(DeclT *D);

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -100,6 +100,18 @@ namespace cling {
     ///
     bool VisitUsingShadowDecl(clang::UsingShadowDecl* USD);
 
+    ///\brief Removes a using declaration
+    /// This method iterates all of the shadows it is holding and calls
+    /// VisitUsingShadowDecl on them.
+    /// It is provided to fix issues where a declaration is removed
+    /// to many times (see test/CodeUnloading/UsingShadows.C)
+    ///
+    ///\param[in] UD - The using declararion to be removed
+    ///
+    ///\returns true on success.
+    ///
+    bool VisitUsingDecl(clang::UsingDecl* UD);
+
     ///\brief Removes a typedef name decls. A base class for TypedefDecls and
     /// TypeAliasDecls.
     ///\param[in] TND - The declaration to be removed.

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -286,6 +286,18 @@ namespace cling {
     ///
     void CollectFilesToUncache(clang::SourceLocation Loc);
 
+    ///\brief Test if the given SourceLocation came before the SourceLocation
+    /// of our Transaction.  If m_CurTransaction is NULL it is assumed to be
+    /// known that the declaration occured in the current Transaction.
+    ///
+    /// This is used to test whether the declaration holding specializations
+    /// was actullay part of the transaction being unloaded.
+    ///
+    bool wasInstatiatedBefore(clang::Decl *D, const clang::SourceLocation &Loc) const;
+
+    template <class DeclT>
+    bool VisitSpecializations(DeclT *D);
+
     LLVM_CONSTEXPR static bool isDefinition(void*) { return false; }
     static bool isDefinition(clang::TagDecl* R);
 

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -208,6 +208,11 @@ namespace cling {
     ///
     bool VisitRecordDecl(clang::RecordDecl* RD);
 
+    ///\brief Removes a CXXRecordDecl. This removes a few cached Decls
+    /// in the sema but otherwise calls through to VisitRecordDecl
+    ///
+    bool VisitCXXRecordDecl(clang::CXXRecordDecl* RD);
+
     ///\brief Remove the macro from the Preprocessor.
     /// @param[in] MD - The MacroDirectiveInfo containing the IdentifierInfo and
     ///                MacroDirective to forward.

--- a/lib/Interpreter/Transaction.cpp
+++ b/lib/Interpreter/Transaction.cpp
@@ -374,10 +374,10 @@ namespace cling {
 
   SourceLocation
   Transaction::getSourceStart(const clang::SourceManager& SM) const {
-    // Children can have invalid BufferIDs. In that case use the parent's.
-    if (m_BufferFID.isInvalid() && m_Parent)
-      return m_Parent->getSourceStart(SM);
-    return SM.getLocForStartOfFile(m_BufferFID);
+    if (m_BufferFID.isValid())
+      return SM.getLocForStartOfFile(m_BufferFID);
+    // Check the parent if there is one.
+    return m_Parent ? m_Parent->getSourceStart(SM) : SourceLocation();
   }
 
 } // end namespace cling

--- a/test/CodeUnloading/BadAlloc.C
+++ b/test/CodeUnloading/BadAlloc.C
@@ -1,0 +1,46 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling --noruntime -Xclang -verify 2>&1 | FileCheck %s
+// Test unloadStdBadAlloc
+
+extern "C" int printf(const char*,...);
+
+#include <new>
+try {
+  throw std::bad_alloc();
+} catch (const std::bad_alloc& e) {
+  printf("CAUGHT 0\n");
+  // CHECK: CAUGHT 0
+}
+.undo
+.undo
+
+#include <new>
+try {
+  throw std::bad_alloc();
+} catch (const std::bad_alloc& e) {
+  printf("CAUGHT 1\n");
+  // CHECK: CAUGHT 1
+}
+.undo
+.undo
+
+#include <new>
+try {
+  throw std::bad_alloc();
+} catch (const std::exception& e) {
+  printf("CAUGHT 2\n");
+  // CHECK: CAUGHT 2
+}
+
+printf("OUT\n");
+// CHECK: OUT
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/ForwardReturn.C
+++ b/test/CodeUnloading/ForwardReturn.C
@@ -1,0 +1,48 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling --noruntime -Xclang -verify 2>&1 | FileCheck --allow-empty %s
+// Test unloadForwardReturn
+
+.storeState "A"
+
+.rawInput
+struct TEST* funcReturnA() { return 0; }
+struct TEST* funcReturnB() { return 0; }
+struct TEST* funcReturnC() { return 0; }
+.rawInput
+
+.undo
+.undo
+.undo
+.compareState "A"
+// CHECK-NOT: Differences
+
+.rawInput
+struct TEST* funcReturnA() { return 0; }
+struct TEST { int a, b, c; };
+.storeState "B"
+struct TEST* funcReturnB() { return 0; }
+struct TEST* funcReturnC() { return 0; }
+.rawInput
+
+.undo
+.undo
+.compareState "B"
+// CHECK-NOT: Differences
+
+TEST t = { 30, 40, 50 };
+.undo
+.undo
+.undo
+
+.compareState "A"
+// CHECK-NOT: Differences
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/Friend.C
+++ b/test/CodeUnloading/Friend.C
@@ -1,0 +1,31 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I %S 2>&1 | FileCheck -allow-empty %s
+// Test friendUnload
+
+void bestFriend();
+
+.storeState "NF"
+#include "Friend.h"
+.undo
+.compareState "NF"
+//CHECK-NOT: Differences
+
+#include "FriendNested.h"
+.undo
+.compareState "NF"
+//CHECK-NOT: Differences
+
+// STL has many of these in memory & stdexcept
+//#include <memory>
+//.undo
+//#include <memory>
+
+//expected-no-diagnostics
+.q

--- a/test/CodeUnloading/Friend.C
+++ b/test/CodeUnloading/Friend.C
@@ -29,9 +29,9 @@ void bestFriend();
 
 
 // STL has many of these in memory & stdexcept
-//#include <memory>
-//.undo
-//#include <memory>
+#include <memory>
+.undo
+#include <memory>
 
 //expected-no-diagnostics
 .q

--- a/test/CodeUnloading/Friend.C
+++ b/test/CodeUnloading/Friend.C
@@ -22,6 +22,12 @@ void bestFriend();
 .compareState "NF"
 //CHECK-NOT: Differences
 
+#include "FriendRecursive.h"
+.undo
+.compareState "NF"
+//CHECK-NOT: Differences
+
+
 // STL has many of these in memory & stdexcept
 //#include <memory>
 //.undo

--- a/test/CodeUnloading/Friend.h
+++ b/test/CodeUnloading/Friend.h
@@ -1,0 +1,9 @@
+class Test {
+  friend void bestFriend();
+  friend void testFriend();
+  friend class FC;
+  class FCD {};
+  friend class FCD;
+  template <class T> friend class FCT;
+  template <class T> friend void testFriendT();
+};

--- a/test/CodeUnloading/FriendNested.h
+++ b/test/CodeUnloading/FriendNested.h
@@ -1,0 +1,5 @@
+class TestNestedParent {
+  class TestNestedChild {
+    friend TestNestedParent;
+  };
+};

--- a/test/CodeUnloading/FriendRecursive.h
+++ b/test/CodeUnloading/FriendRecursive.h
@@ -1,0 +1,9 @@
+class TestA {
+  friend class TestB;
+  void empty() {}
+};
+
+class TestB {
+  friend class TestA;
+  void empty() {}
+};

--- a/test/CodeUnloading/InitializerList.C
+++ b/test/CodeUnloading/InitializerList.C
@@ -9,9 +9,14 @@
 // RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
 // Test unloadInitializerList
 
+// FIXME: REMOVE once print unloading is merged
+extern "C" int printf(const char*, ...);
+
 #include "InitializerList.h"
 TestIList<int,10> t = {0,1,2,3,4,5,6,7,8,9};
-t.sum()
+// REMOVE ->
+printf("(int) %d\n", t.sum());
+// <- REMOVE, REPLACE: t.sum()
 // CHECK: (int) 45
 .undo
 .undo
@@ -19,7 +24,9 @@ t.sum()
 
 #include "InitializerList.h"
 TestIList<int,15> t = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
-t.sum()
+// REMOVE ->
+printf("(int) %d\n", t.sum());
+// <- REMOVE, REPLACE: t.sum()
 // CHECK-NEXT: (int) 120
 .undo
 .undo
@@ -38,12 +45,12 @@ TestIList<float,4> tf = {10,20,30,40};
 tf.sum()
 // CHECK-NEXT: (float) 100.00000f
 
-// Still busted because of inlining problems
-// #include <vector>
-// std::vector<int> v = { 0, 1, 2, 3, 4, 5 };
-// .undo
-// .undo
+#include <vector>
+std::vector<int> v = { 0, 1, 2, 3, 4, 5 };
+.undo
+.undo
 
+// Still busted because of template problems
 // #include <vector>
 // std::vector<int> v1 = { 0, 1, 2, 3, 4, 5 };
 // v1

--- a/test/CodeUnloading/InitializerList.C
+++ b/test/CodeUnloading/InitializerList.C
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
+// Test unloadInitializerList
+
+#include "InitializerList.h"
+TestIList<int,10> t = {0,1,2,3,4,5,6,7,8,9};
+t.sum()
+// CHECK: (int) 45
+.undo
+.undo
+.undo
+
+#include "InitializerList.h"
+TestIList<int,15> t = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
+t.sum()
+// CHECK-NEXT: (int) 120
+.undo
+.undo
+.undo
+
+#include "InitializerList.h"
+TestIList<int,20> ta = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20};
+ta.sum()
+// CHECK-NEXT: (int) 210
+
+TestIList<int,4> tb = {1,2,3,4};
+tb.sum()
+// CHECK-NEXT: (int) 10
+
+TestIList<float,4> tf = {10,20,30,40};
+tf.sum()
+// CHECK-NEXT: (float) 100.00000f
+
+// Still busted because of inlining problems
+// #include <vector>
+// std::vector<int> v = { 0, 1, 2, 3, 4, 5 };
+// .undo
+// .undo
+
+// #include <vector>
+// std::vector<int> v1 = { 0, 1, 2, 3, 4, 5 };
+// v1
+// // 0CHECK: (std::vector<int> &) { 0, 1, 2, 3, 4, 5 }
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/InitializerList.h
+++ b/test/CodeUnloading/InitializerList.h
@@ -1,0 +1,19 @@
+
+#include <initializer_list>
+
+template <class T, unsigned N>
+class TestIList {
+  T m_Data[N];
+public:
+  TestIList(std::initializer_list<T> l) {
+    int i = 0;
+    for (T val: l )
+      m_Data[i++] = val;
+  }
+  T sum() const {
+    T rval = 0;
+    for (int i = 0; i < N; ++i)
+      rval += m_Data[i];
+    return rval;
+  }
+};

--- a/test/CodeUnloading/Math.C
+++ b/test/CodeUnloading/Math.C
@@ -1,0 +1,17 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1
+// Test unloadMath
+
+#include <math.h>
+.undo
+// used to be a problem unloading here
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/Math.C
+++ b/test/CodeUnloading/Math.C
@@ -6,12 +6,22 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1
+// RUN: cat %s | %cling --noruntime -I%S -Xclang -verify 2>&1 | FileCheck --allow-empty %s
 // Test unloadMath
 
+// grab all the builtins we can
 #include <math.h>
 .undo
 // used to be a problem unloading here
+
+.storeState "A"
+#include <math.h>
+#include <stddef.h>
+.undo
+.undo
+.compareState "A"
+// nullptr_t using declaration used to hang around
+// CHECK-NOT: Differences
 
 // expected-no-diagnostics
 .q

--- a/test/CodeUnloading/NameSpaces.C
+++ b/test/CodeUnloading/NameSpaces.C
@@ -24,6 +24,18 @@
 #undef TEST_NAMESPACE
 
 
+namespace A{}
+namespace A { inline namespace __BBB { int f; } }
+namespace A { inline namespace __BBB { int f1; } }
+namespace A { inline namespace __BBB { int f2; } }
+.undo
+A::f2 // expected-error {{no member named 'f2' in namespace 'A'}}
+.undo
+A::f1 // expected-error {{no member named 'f1' in namespace 'A'}}
+.undo
+A::f // expected-error {{no member named 'f' in namespace 'A'}}
+
+
 #include <stdexcept>
 .undo
 #include <stdexcept>
@@ -32,5 +44,4 @@
 101
 // CHECK: (int) 101
 
-// expected-no-diagnostics
 .q

--- a/test/CodeUnloading/NameSpaces.C
+++ b/test/CodeUnloading/NameSpaces.C
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+// Test inlineNamespaces
+
+#define TEST_NAMESPACE test
+#include "NameSpaces.h"
+.undo
+#include "NameSpaces.h"
+.undo
+#undef TEST_NAMESPACE
+
+#define TEST_NAMESPACE std
+#include "NameSpaces.h"
+.undo
+#include "NameSpaces.h"
+.undo
+#undef TEST_NAMESPACE
+
+
+#include <stdexcept>
+.undo
+#include <stdexcept>
+.undo
+
+101
+// CHECK: (int) 101
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/NameSpaces.h
+++ b/test/CodeUnloading/NameSpaces.h
@@ -1,0 +1,13 @@
+
+namespace TEST_NAMESPACE {
+  inline namespace nested {
+    class Nested;
+  }
+}
+
+namespace TEST_NAMESPACE {
+  class Test {
+  public:
+    Test(const Nested&);
+  };
+}

--- a/test/CodeUnloading/NestedNameSpaces.C
+++ b/test/CodeUnloading/NestedNameSpaces.C
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling --noruntime -I%S -Xclang -verify 2>&1
+// RUN: cat %s | %cling -I%S -Xclang -verify  2>&1 | FileCheck %s -allow-empty
+// Test nested-namespace
+
+
+namespace A { }
+.storeState "A"
+namespace A { inline namespace __1 {} }
+.storeState "__1"
+namespace A { inline namespace __1 { inline namespace __2 {} } }
+namespace A { inline namespace __1 { inline namespace __2 { struct T {}; }} }
+
+.undo
+.undo
+.compareState "__1"
+// CHECK-NOT: Differences
+        
+namespace A { inline namespace __1 { namespace __2 {} } }
+namespace A { inline namespace __1 { namespace __2 { struct T {}; }} }
+.undo
+.undo
+.compareState "__1"
+
+.undo
+.compareState "A"
+// CHECK-NOT: Differences
+
+namespace A { namespace __1 {} }
+.storeState "__1"
+namespace A { namespace __1 { inline namespace __2 {} } }
+namespace A { namespace __1 { inline namespace __2 { struct T {}; } } }
+
+.undo
+.undo
+.compareState "__1"
+// CHECK-NOT: Differences
+
+.undo
+.compareState "A"
+// CHECK-NOT: Differences
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/New.C
+++ b/test/CodeUnloading/New.C
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S --noruntime -Xclang -verify 2>&1 | FileCheck %s
+// Test unloadNew
+
+extern "C" int printf(const char*,...);
+
+#include <new>
+.undo
+
+#include "OpNew.h"
+Test *t = new Test;
+// CHECK: Test::operator new
+
+delete t;
+// CHECK: Test::operator delete
+
+.undo // delete t;
+.undo // new Test;
+.undo // #include "OpNew.h"
+
+#include <new>
+.undo //#include <new>
+
+// Now we are at line 13
+#include <new>
+
+.rawInput
+// CHECK: Using raw input
+static unsigned long allocFact(unsigned N) {
+  unsigned *test = new unsigned[N];
+  for (int i = 0; i < N; ++i)
+    test[i] = i+1;
+
+  unsigned long fact = 1;
+  for (int i = 0; i < N; ++i)
+    fact *= test[i];
+
+  delete [] test;
+  return fact;
+}
+
+static unsigned long factorial(unsigned long n) {
+  return (n < 2) ? 1 : (factorial(n - 1) * n);
+}
+.rawInput
+// CHECK: Not using raw input
+
+printf("%lu == %lu\n", allocFact(12), factorial(12));
+// CHECK: 479001600 == 479001600
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/New.C
+++ b/test/CodeUnloading/New.C
@@ -19,7 +19,7 @@ Test *t = new Test;
 // CHECK: Test::operator new
 
 delete t;
-// CHECK: Test::operator delete
+// CHECK-NEXT: Test::operator delete
 
 .undo // delete t;
 .undo // new Test;
@@ -31,8 +31,10 @@ delete t;
 // Now we are at line 13
 #include <new>
 
+
+// Make sure we can still allocate some memory
 .rawInput
-// CHECK: Using raw input
+// CHECK-NEXT: Using raw input
 static unsigned long allocFact(unsigned N) {
   unsigned *test = new unsigned[N];
   for (int i = 0; i < N; ++i)
@@ -50,10 +52,44 @@ static unsigned long factorial(unsigned long n) {
   return (n < 2) ? 1 : (factorial(n - 1) * n);
 }
 .rawInput
-// CHECK: Not using raw input
+// CHECK-NEXT: Not using raw input
 
 printf("%lu == %lu\n", allocFact(12), factorial(12));
-// CHECK: 479001600 == 479001600
+// CHECK-NEXT: 479001600 == 479001600
+
+
+// Make sure we can still overload new
+#include "OpNew.h"
+Test *t = new Test;
+// CHECK-NEXT: Test::operator new
+
+delete t;
+// CHECK-NEXT: Test::operator delete
+
+
+// Make sure allocation still works back to initial state (1 transaction)
+.undo
+.undo
+.undo
+.undo
+.undo
+.undo
+.undo
+.undo
+.stats undo
+// CHECK-NEXT: <cling::Transaction* 0x{{[0-9a-f]+}} isEmpty=0 isCommitted=1>
+
+unsigned *uptr = new unsigned[5];
+for (unsigned i = 0; i < 5; ++i) {
+  uptr[i] = 0xdeadbef0 + i;
+}
+
+extern "C" int printf(const char*,...);
+for (unsigned i = 0; i < 5; ++i) {
+  printf("%X", uptr[i]);
+}
+printf("\n");
+// CHECK-NEXT: DEADBEF0DEADBEF1DEADBEF2DEADBEF3DEADBEF4
 
 // expected-no-diagnostics
 .q

--- a/test/CodeUnloading/New.C
+++ b/test/CodeUnloading/New.C
@@ -78,6 +78,7 @@ delete t;
 .undo
 .stats undo
 // CHECK-NEXT: <cling::Transaction* 0x{{[0-9a-f]+}} isEmpty=0 isCommitted=1>
+// CHECK-NEXT: `   <cling::Transaction* 0x{{[0-9a-f]+}} isEmpty=0 isCommitted=1>
 
 unsigned *uptr = new unsigned[5];
 for (unsigned i = 0; i < 5; ++i) {

--- a/test/CodeUnloading/OpNew.h
+++ b/test/CodeUnloading/OpNew.h
@@ -1,0 +1,15 @@
+
+#include <stdlib.h>
+extern "C" int printf(const char*,...);
+
+class Test {
+public:
+  void* operator new  ( size_t count ) {
+    printf("Test::operator new\n");
+    return ::malloc(count);
+  }
+  void operator delete(void* ptr) {
+    printf("Test::operator delete\n");
+    return ::free(ptr);
+  }
+};

--- a/test/CodeUnloading/Reloader.C
+++ b/test/CodeUnloading/Reloader.C
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling --noruntime -DCLING_NO_NORUTIME -I%S -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+// Test reload-differing-layouts
+
+extern "C" int printf(const char*, ...);
+
+// FIXME: Would be nice to have FileCheck verify type-name matches between lines
+#define DUMP_TYPE typeid(std::string).name()
+#include <typeinfo>
+
+#include <string>
+printf("%s %s\n", std::string("std::string").c_str(), DUMP_TYPE);
+.undo
+.undo
+// CHECK: std::string
+
+#include "Reloader.h"
+printf("%s %s\n", std::string("local::string").c_str(), DUMP_TYPE);
+.undo
+.undo
+// CHECK-NEXT: local::string
+
+#include <string>
+printf("%s %s\n", std::string("std::string(2)").c_str(), DUMP_TYPE);
+.undo
+.undo
+// CHECK-NEXT: std::string(2)
+
+.undo // #include <typeinfo>
+
+#ifdef CLING_NO_NORUTIME
+ #define POSE_AS_STD_NAMESPACE_ namespace std { inline namespace __1 {
+ #define _POSE_AS_STD_NAMESPACE } }
+#endif
+
+#define POSE_NOT_TEMPLATED
+#include "Reloader.h"
+
+printf("%s\n", std::string("local::string(2)").c_str());
+.undo
+.undo
+// CHECK-NEXT: local::string(2)
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/Reloader.C
+++ b/test/CodeUnloading/Reloader.C
@@ -8,6 +8,11 @@
 
 // RUN: cat %s | %cling --noruntime -DCLING_NO_NORUTIME -I%S -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+// XFAIL: *
+// Changes to CodeGenModule::Release() breaks this test:
+//     DeferredDecls.insert(EmittedDeferredDecls.begin(),
+//                          EmittedDeferredDecls.end());
+
 // Test reload-differing-layouts
 
 extern "C" int printf(const char*, ...);

--- a/test/CodeUnloading/Reloader.h
+++ b/test/CodeUnloading/Reloader.h
@@ -1,0 +1,40 @@
+
+#if !defined(POSE_AS_STD_NAMESPACE_)
+ #if defined(_LIBCPP_VERSION)
+  #define POSE_AS_STD_NAMESPACE_    _LIBCPP_BEGIN_NAMESPACE_STD
+  #define _POSE_AS_STD_NAMESPACE    _LIBCPP_END_NAMESPACE_STD
+ #elif defined(_GLIBCXX_VISIBILITY)
+  #define POSE_AS_STD_NAMESPACE_    namespace std _GLIBCXX_VISIBILITY(default) { _GLIBCXX_BEGIN_NAMESPACE_VERSION
+  #define _POSE_AS_STD_NAMESPACE    _GLIBCXX_END_NAMESPACE_VERSION }
+ #else
+  #define POSE_AS_STD_NAMESPACE_    _STD_BEGIN
+  #define _POSE_AS_STD_NAMESPACE    _STD_END
+ #endif
+#endif
+
+POSE_AS_STD_NAMESPACE_
+
+#if defined(POSE_NOT_TEMPLATED)
+  class string {
+    void* m_Pad[10];
+    const char* m_Val;
+  public:
+    string(const char* CStr) : m_Val(CStr) {}
+    const char* c_str() const { return m_Val; }
+  };
+#else
+  template <class T> class char_traits {};
+  template <class T> class allocator {};
+  template<class Elem, class Traits, class Alloc>
+  class basic_string {
+    void* m_Pad[20];
+    const char* m_Val;
+  public:
+    basic_string(const char* CStr) : m_Val(CStr) {}
+    const char* c_str() const { return m_Val; }
+  };
+
+  typedef basic_string<char, char_traits<char>, allocator<char> > string;
+#endif
+
+_POSE_AS_STD_NAMESPACE

--- a/test/CodeUnloading/STL.C
+++ b/test/CodeUnloading/STL.C
@@ -1,0 +1,48 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+// Test stlUnloading
+
+#include <string>
+.undo
+#include <string>
+.undo
+
+#include <map>
+.undo
+#include <map>
+.undo
+
+#include <new>
+#include <string>
+#include <map>
+
+typedef std::map<int, std::string> strmap;
+.undo // typedef above
+.undo // #include <map>
+
+typedef std::string teststring;
+.undo // typedef above
+.undo // #include <string>
+
+#include <map>
+#include <string>
+typedef std::map<int, std::string> strmap;
+
+strmap test;
+test[1] = "TEST";
+
+(const char*) test[1].c_str()
+// CHECK: (const char *) "TEST"
+
+// There are still quite a few built-ins added which make compareState
+// useless. But the fact we made it to here without an error ain't bad.
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/STLNoRuntime.C
+++ b/test/CodeUnloading/STLNoRuntime.C
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling --noruntime -I%S -Xclang -verify 2>&1 | FileCheck %s
+// Test stlUnloadingNoRuntime
+
+extern "C" int printf(const char*, ...);
+
+#include <new>
+.undo
+#include <new>
+.undo
+
+#include <string>
+.undo
+#include <string>
+.undo
+
+#include <map>
+.undo
+#include <map>
+.undo
+
+#include <new>
+#include <string>
+#include <map>
+
+typedef std::map<int, std::string> strmap;
+.undo // typedef above
+.undo // #include <map>
+
+typedef std::string teststring;
+.undo // typedef above
+.undo // #include <string>
+
+#include <map>
+#include <string>
+typedef std::map<int, std::string> strmap;
+
+strmap test;
+test[1] = "TEST";
+
+char *str = new char[10];
+for (int i = 0; i < 9; ++i) str[i] = 'A'+i;
+str[9] = 0;
+
+printf("%s %s\n", test[1].c_str(), str);
+// CHECK: TEST ABCDEFGHI
+
+// There are still quite a few built-ins added which make compareState
+// useless. But the fact we made it to here without an error ain't bad.
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/SizeT.C
+++ b/test/CodeUnloading/SizeT.C
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+// Test size_t-using
+
+// FIXME: This test probably becomes useless once ciso646 is the default include
+#include <cstddef>
+#include <cstring>
+.undo
+
+std::size_t P = 201
+// CHECK: (unsigned {{long|int|long long}}) 201
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/SysError.C
+++ b/test/CodeUnloading/SysError.C
@@ -1,0 +1,23 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// Primarily for Windows
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+// Test system_error-undo
+
+#include <system_error>
+.undo
+#include <system_error>
+.undo
+
+#include <string>
+std::string("TEST")
+// CHECK: (std::string) "TEST"
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/TemplDefaultArgs.C
+++ b/test/CodeUnloading/TemplDefaultArgs.C
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+// Test templated-default-args
+
+#include <iterator>
+#include <vector>
+.undo
+#include <vector>
+
+std::vector<int> Vec(6, 6)
+// CHECK: (std::vector<int> &) { 6, 6, 6, 6, 6, 6 }
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/TemplFriend.C
+++ b/test/CodeUnloading/TemplFriend.C
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+// Test templated-friends
+
+#include "TemplFriend.h"
+.undo
+#include "TemplFriend.h"
+
+Test(5).Vec
+// CHECK: (std::vector<int>) { 5, 5, 5, 5, 5 }
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/TemplFriend.h
+++ b/test/CodeUnloading/TemplFriend.h
@@ -1,0 +1,10 @@
+#include <iterator>
+#include <vector>
+
+struct Test {
+  std::vector<int> Vec;
+  typedef std::vector<int>::const_iterator iterator;
+  iterator begin() const { return Vec.begin(); }
+  iterator end() const { return Vec.end(); }
+  Test(int i) : Vec(i, i) {}
+};

--- a/test/CodeUnloading/TemplPrivate.C
+++ b/test/CodeUnloading/TemplPrivate.C
@@ -1,0 +1,19 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -DTEST_LITE=1 -I%S --noruntime -Xclang -verify 2>&1
+// RUN: cat %s | %cling -I%S --noruntime -Xclang -verify 2>&1
+// Test privateTemplateFunctionParam
+
+.storeState "Initial"
+#include "TemplPrivate.h"
+.undo
+.compareState "Initial"
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/TemplPrivate.h
+++ b/test/CodeUnloading/TemplPrivate.h
@@ -1,0 +1,66 @@
+
+#if TEST_LITE
+
+class TrailingObjectsBase {
+protected: // This is causing the error
+  struct OverloadToken {};
+};
+
+template <typename BaseTy>
+struct TrailingObjectsImpl {
+};
+
+template <typename BaseTy>
+class TrailingObjects : TrailingObjectsImpl<BaseTy> {
+  static int
+  callNumTrailingObjects(const BaseTy *Obj,
+                         TrailingObjectsBase::OverloadToken) {
+    return 1;
+  }
+
+  template <typename T>
+  static int callNumTrailingObjects(const BaseTy *Obj,
+                                    TrailingObjectsBase::OverloadToken) {
+    return Obj->numTrailingObjects(TrailingObjectsBase::OverloadToken());
+  }
+};
+
+#else
+
+namespace trailing_objects_internal {
+class TrailingObjectsBase {
+protected:
+  template <typename T> struct OverloadToken {};
+};
+
+template <int Align, typename BaseTy, typename TopTrailingObj, typename PrevTy,
+          typename... MoreTys>
+struct TrailingObjectsImpl {
+};
+}
+
+template <typename BaseTy, typename... TrailingTys>
+class TrailingObjects : private trailing_objects_internal::TrailingObjectsImpl<
+                            1,
+                            BaseTy, TrailingObjects<BaseTy, TrailingTys...>,
+                            BaseTy, TrailingTys...>
+{
+  template <int A, typename B, typename T, typename P, typename... M>
+  friend struct trailing_objects_internal::TrailingObjectsImpl;
+
+  using TrailingObjectsBase = trailing_objects_internal::TrailingObjectsBase;
+
+  static int
+  callNumTrailingObjects(const BaseTy *Obj,
+                         TrailingObjectsBase::OverloadToken<BaseTy>) {
+    return 1;
+  }
+
+  template <typename T>
+  static int callNumTrailingObjects(const BaseTy *Obj,
+                                    TrailingObjectsBase::OverloadToken<T>) {
+    return Obj->numTrailingObjects(TrailingObjectsBase::OverloadToken<T>());
+  }
+};
+
+#endif

--- a/test/CodeUnloading/TemplPrivateFull.C
+++ b/test/CodeUnloading/TemplPrivateFull.C
@@ -1,0 +1,23 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %built_cling --noruntime -Wno-undefined-inline -Xclang -verify 2>&1
+// Test clangDeclInclude
+
+#include <clang/AST/Decl.h>
+.undo
+// FIXME: Fails because of a lot of built-ins
+// .compareState "Initial"
+
+fabs // expected-error {{use of undeclared identifier 'fabs'}}
+
+// Include it again though!
+#include <clang/AST/Decl.h>
+.undo
+
+.q

--- a/test/CodeUnloading/TypeInfo.C
+++ b/test/CodeUnloading/TypeInfo.C
@@ -1,0 +1,27 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling --noruntime -Xclang -verify  | FileCheck %s
+// Test unloadTypeInfo
+
+extern "C" int printf(const char*, ...);
+int A, B;
+
+#include <typeinfo>
+printf("Types match: %d\n", typeid(A) == typeid(B));
+// CHECK: Types match: 1
+
+.undo  // undo print
+.undo  // undo #include <typeinfo>
+
+#include <typeinfo>
+printf("Types match: %d\n", typeid(A) == typeid(B));
+// CHECK: Types match: 1
+
+// expected-no-diagnostics
+.q

--- a/test/CodeUnloading/UsingShadows.C
+++ b/test/CodeUnloading/UsingShadows.C
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling 2>&1 | FileCheck -allow-empty %s
+
+
+namespace A { void foo(); }
+.storeState "TESTU1"
+namespace B { using A::foo; }
+.undo
+.compareState "TESTU1"
+// CHECK-NOT: Differences
+
+.storeState "TESTU2"
+namespace B { using A::foo; }
+.undo
+.compareState "TESTU2"
+// CHECK-NOT: Differences
+
+.storeState "TESTU3"
+namespace B { using A::foo; }
+.undo
+
+.compareState "TESTU3"
+// CHECK-NOT: Differences
+
+
+.q

--- a/test/CodeUnloading/UsingShadows.C
+++ b/test/CodeUnloading/UsingShadows.C
@@ -6,8 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling 2>&1 | FileCheck -allow-empty %s
-
+// RUN: cat %s | %cling -I %S 2>&1 | FileCheck %s
 
 namespace A { void foo(); }
 .storeState "TESTU1"
@@ -29,5 +28,28 @@ namespace B { using A::foo; }
 .compareState "TESTU3"
 // CHECK-NOT: Differences
 
+typedef long long_t;
 
+.storeState "TEST4"
+
+#include "UsingShadows.h"
+#include "UsingShadows.h"
+#include "UsingShadows.h"
+.undo
+.undo
+.undo
+
+//Make sure long_t is still valid
+.compareState "TEST4"
+// CHECK-NOT: Differences
+
+long_t val = 9;
+val
+// CHECK: 9
+
+// Unloading <string> used to fail as well (which as annoying).
+#include <string>
+.undo
+
+// expected-no-diagnostics
 .q

--- a/test/CodeUnloading/UsingShadows.C
+++ b/test/CodeUnloading/UsingShadows.C
@@ -94,6 +94,13 @@ typedef long long_t;
 .compareState "TEST4"
 // CHECK-NOT: Differences
 
+#define TEST3
+.storeState "TEST3"
+#include "UsingShadows.h"
+.undo
+.compareState "TEST3"
+// CHECK-NOT: Differences
+
 long_t val = 9;
 val
 // CHECK-NEXT: 9

--- a/test/CodeUnloading/UsingShadows.h
+++ b/test/CodeUnloading/UsingShadows.h
@@ -1,6 +1,4 @@
-namespace test {
-  using ::long_t;
-}
+#ifndef TEST3
 
 namespace test {
   using ::long_t;
@@ -9,3 +7,26 @@ namespace test {
 namespace test {
   using ::long_t;
 }
+
+namespace test {
+  using ::long_t;
+}
+
+#else
+
+extern "C" {
+  double adblf(double);
+}
+namespace test {
+  using ::adblf;
+
+  constexpr float
+  adblf(float __x);
+
+  constexpr long double
+  adblf(long double __x);
+}
+
+using test::adblf;
+
+#endif

--- a/test/CodeUnloading/UsingShadows.h
+++ b/test/CodeUnloading/UsingShadows.h
@@ -1,0 +1,11 @@
+namespace test {
+  using ::long_t;
+}
+
+namespace test {
+  using ::long_t;
+}
+
+namespace test {
+  using ::long_t;
+}

--- a/test/ErrorRecovery/Instantiation.C
+++ b/test/ErrorRecovery/Instantiation.C
@@ -1,0 +1,109 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
+// Test instantiationRecover
+
+extern "C" int printf(const char*,...);
+
+template <class T> static void bracketIt(const T& iter, const char *f = " %d") {
+  printf("{");
+  for (auto val : iter )
+    printf(f, val);
+  printf(" }\n");
+}
+
+#define TEST_TMPLT
+#define TEST_CLASS TestV
+#define TEST_VALT  int
+#include "Instantiation.h"
+TestV tv;
+for (auto val : tv(10) ) { *val; }
+// expected-error@2 {{indirection requires pointer operand ('int' invalid)}}
+bracketIt(tv(10));
+// CHECK: { 0 1 2 3 4 5 6 7 8 9 }
+#undef TEST_TMPLT
+#undef TEST_CLASS
+#undef TEST_VALT
+
+
+#define TEST_TMPLT template <class T>
+#define TEST_CLASS TestT
+#define TEST_VALT  T
+#include "Instantiation.h"
+TestT<float> tt;
+for (auto val : tt(15) ) { val->failure; }
+// expected-error@2 {{member reference type 'float' is not a pointer}}
+bracketIt(tt(15), " %.1f");
+// CHECK: { 0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 }
+#undef TEST_TMPLT
+#undef TEST_CLASS
+#undef TEST_VALT
+
+
+#include "Instantiation.h"
+
+TestStatic<int> ts0;
+for (auto val : ts0 ) { val(); }
+// expected-error@2 {{called object type 'int' is not a function or function pointer}}
+bracketIt(ts0);
+// CHECK: { 0 }
+
+TestStatic<int> ts1;
+for (auto val : ts1 ) { val(); }
+// expected-error@2 {{called object type 'int' is not a function or function pointer}}
+bracketIt(ts1);
+// CHECK: { 0 1 }
+
+TestStatic<int> ts2;
+for (auto val : ts2 ) { val(); }
+// expected-error@2 {{called object type 'int' is not a function or function pointer}}
+bracketIt(ts2);
+// CHECK: { 0 1 2 }
+
+
+TestIterInst<int> ti;
+for (auto val : ti.test1(12) ) { val(); }
+// expected-error@2 {{called object type 'int' is not a function or function pointer}}
+bracketIt(ti.test1(12));
+// CHECK: { 0 1 2 3 4 5 6 7 8 9 10 11 }
+
+TestIterInst<int> ti2;
+for (auto val : ti2.test2(20) ) { val.failure; }
+// expected-error@2 {{member reference base type 'int' is not a structure or union}}
+bracketIt(ti2.test2(20));
+// CHECK: { 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 }
+
+ti2.access()
+// CHECK: (bool) true
+
+
+
+#include <vector>
+std::vector<int> v = { 0, 1, 2, 3, 4, 5 };
+for (auto val : v ) { val[5]; }
+// expected-error@2 {{subscripted value is not an array, pointer, or vector}}
+bracketIt(v);
+// CHECK: { 0 1 2 3 4 5 }
+
+
+#include <string>
+std::string test("later");
+(const char*) test.c_str()
+// CHECK: (const char *) "later"
+
+
+
+TestStatic<int> ts3;
+for (auto val : ts2 ) { val(); }
+// expected-error@2 {{called object type 'int' is not a function or function pointer}}
+bracketIt(ts3);
+// CHECK: { 0 1 2 3 }
+
+
+.q

--- a/test/ErrorRecovery/Instantiation.h
+++ b/test/ErrorRecovery/Instantiation.h
@@ -1,0 +1,57 @@
+
+#ifdef TEST_CLASS
+
+TEST_TMPLT class TEST_CLASS {
+  typedef TEST_VALT value_type;
+  value_type m_Size;
+public:
+  class iterator {
+    value_type m_Val;
+  public:
+    iterator(value_type val) : m_Val(val) {}
+    bool operator != ( const iterator &rhs ) const { return m_Val != rhs.m_Val; }
+    iterator& operator ++ () { ++m_Val; return *this; }
+    value_type operator * () const { return m_Val; };
+  };
+  iterator begin() const { return iterator(0); }
+  iterator end()   const { return iterator(m_Size); }
+  TEST_CLASS & operator() (value_type val) { m_Size = val; return *this; }
+};
+
+#else
+
+template <class T>
+class TestIter {
+  T m_Val;
+public:
+  TestIter(T val) : m_Val(val) {}
+  bool operator != ( const TestIter<T> &rhs ) const { return m_Val != rhs.m_Val; }
+  TestIter& operator ++ () { ++m_Val; return *this; }
+  T operator * () const { return m_Val; };
+};
+
+template <class T>
+class TestIterInst {
+  T m_Size;
+public:
+  bool operator == ( const TestIterInst<T>& rhs ) const { return false; }
+  TestIter<T> begin() const { return TestIter<T>(0); }
+  TestIter<T> end()   const { return TestIter<T>(m_Size); }
+  TestIterInst&    test1(T val) { m_Size = val; return *this; }
+  TestIterInst<T>& test2(T val) { m_Size = val; return *this; }
+  bool access() const { return testAccessDecl(); }
+private:
+  bool testAccessDecl() const { return true; }
+};
+
+template <class T>
+class TestStatic {
+  static T s_Counter;
+public:
+  TestStatic() { ++s_Counter; }
+  TestIter<T> begin() const { return TestIter<T>(0); }
+  TestIter<T> end()   const { return TestIter<T>(s_Counter); }
+};
+template<> int TestStatic<int>::s_Counter = 0;
+
+#endif

--- a/test/ErrorRecovery/InstantiationFail.C
+++ b/test/ErrorRecovery/InstantiationFail.C
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// This currently fails becuase TestStatic<> is fully instantiated due to
+// the static variable initialization.
+// TestStatic<> now references TestIter<int> (A).
+// After TestIterInst<> failure, TestIter<> (A) is unloaded, then later
+// re-instantiated as TestIter<> (B).
+// When 'for (auto val : ts0 )' is compiled it is expecting a TestIter<> (B)
+// but 'TestStatic<>::begin/end' are still returning a TestIter<> (A)
+//
+// Later uses will work; however, as the bad failure causes begin and end on
+// TestStatic<> to be reinstantiated with TestIter<> (B).
+
+// Test instantiationRecover
+// RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
+// XFAIL: *
+
+extern "C" int printf(const char*,...);
+#include "Instantiation.h"
+
+TestIterInst<int> ti;
+for (auto val : ti.test1(12) ) { val(); }
+// expected-error@2 {{called object type 'int' is not a function or function pointer}}
+
+TestStatic<int> ts0;
+for (auto val : ts0 ) { printf("{ %d }\n", val); }
+// CHECK: { 0 }
+
+.q

--- a/test/ErrorRecovery/InstantiationStatic.C
+++ b/test/ErrorRecovery/InstantiationStatic.C
@@ -19,7 +19,6 @@
 
 // Test instantiationRecover
 // RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
-// XFAIL: *
 
 extern "C" int printf(const char*,...);
 #include "Instantiation.h"

--- a/test/ErrorRecovery/MisorderedIncludes.C
+++ b/test/ErrorRecovery/MisorderedIncludes.C
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling 2>&1 | FileCheck %s
+// Test misorderedIncludes
+
+
+#include <map>
+.undo
+#include <map>
+.undo
+
+#include <map>
+std::map<int, std::string> test;
+#include <string>
+std::map<int, std::string> test;
+
+test[0] = "A";
+(const char*) test[0].c_str()
+// CHECK: (const char *) "A"
+
+test[10] = "B";
+(const char*) test[10].c_str()
+// CHECK: (const char *) "B"
+
+test[20] = "C";
+(const char*) test[20].c_str()
+// CHECK: (const char *) "C"
+
+test[30] = "LONGER";
+(const char*) test[30].c_str()
+// CHECK: (const char *) "LONGER"
+
+.q

--- a/test/ErrorRecovery/SysErrorSimple.C
+++ b/test/ErrorRecovery/SysErrorSimple.C
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
+
+// Test for Windows simulating:
+// #include <system_error>
+// .undo
+// #include <system_error>
+
+#include "SysErrorSimple.h"
+//.stats decl
+
+#define CLING_SYSERRR_SIMPLE_2
+#include "SysErrorSimple.h"
+//.stats decl
+.undo
+//.stats decl
+
+#include "SysErrorSimple.h"
+.undo
+//.stats decl
+
+#include "SysErrorSimple.h"
+
+Impl<FwdDecl>()(FwdDecl())
+// CHECK: (unsigned int) 101
+
+// expected-no-diagnostics
+.q

--- a/test/ErrorRecovery/SysErrorSimple.h
+++ b/test/ErrorRecovery/SysErrorSimple.h
@@ -1,0 +1,27 @@
+#ifndef CLING_SYSERRR_SIMPLE_2
+
+template <class T>
+struct Base {
+  unsigned operator()(const T& V) const { return V; }
+};
+
+template <class T>
+struct Impl {
+  unsigned operator()(const T& V) const { return 0; }
+};
+
+template<> struct Impl<int> : public Base<int> {
+};
+
+#else
+
+class FwdDecl {
+};
+
+template<> struct Impl<FwdDecl> {
+  unsigned operator()(const FwdDecl& EC) const {
+    return Impl<int>()(101);
+  }
+};
+
+#endif

--- a/test/ErrorRecovery/Vector.C
+++ b/test/ErrorRecovery/Vector.C
@@ -9,13 +9,14 @@
 // RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
 // Test stlVecRecover
 
+#include <iterator>
 #include <vector>
-std::vector<int> v = { 0, 1, 2, 3, 4, 5 };
-for (auto val : v ) *val; // expected-error {{indirection requires pointer operand ('int' invalid)}}
+.undo
 
 #include <string>
 std::string test("later");
 (const char*) test.c_str()
 // CHECK: (const char *) "later"
 
+// expected-no-diagnostics
 .q

--- a/test/ErrorRecovery/Vector.C
+++ b/test/ErrorRecovery/Vector.C
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I %S -Xclang -verify 2>&1 | FileCheck %s
+// Test stlVecRecover
+
+#include <vector>
+std::vector<int> v = { 0, 1, 2, 3, 4, 5 };
+for (auto val : v ) *val; // expected-error {{indirection requires pointer operand ('int' invalid)}}
+
+#include <string>
+std::string test("later");
+(const char*) test.c_str()
+// CHECK: (const char *) "later"
+
+.q


### PR DESCRIPTION
Clang keeps cached copies of a few declarations that makes unload/reload cycle fail:
`operator new/delete
initializer lists
std::bad_alloc`