### PR TITLE
Fix CMake for Ninja on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,11 +209,16 @@ endif ()
 # Lots of cling is needed at runtime (e.g. Value, or Interpreter::Evaluate()).
 # The JIT needs to be able to resolve these symbols from cling; unhide them.
 string(REPLACE "-fvisibility=hidden" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
 # The package needs to be compiler without RTTI information
 if(MSVC)
-  add_definitions(/GR- /DNOMINMAX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 else()
-  add_definitions(-fno-rtti)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+endif()
+
+if(MSVC)
+  add_definitions(/DNOMINMAX)
 endif()
 
 if (APPLE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,16 +11,24 @@ branches:
 
 cache:
   - builddir
+  - C:\projects\deps\ninja
 
 clone_depth: 10
 
-matrix:
-  fast_finish: true   # set this flag to immediately finish build once one of the jobs fails.
-  allow_failures:
-    - platform: x86
-      configuration: Release
-    - platform: x64
-      configuration: Release
+environment:
+  VSTUDIO_VERS: Microsoft Visual Studio 14.0
+  matrix:
+    - CMAKE_GEN: Visual Studio 14 2015 Win64
+    - CMAKE_GEN: Ninja
+
+# matrix:
+#  set this flag to immediately finish build once one of the jobs fails.
+#  fast_finish: true 
+#  allow_failures:
+#  - platform: x86
+#    configuration: Release
+#  - platform: x64
+#    configuration: Release
 
 skip_tags: true
 os:
@@ -32,10 +40,14 @@ build:
 
 
 install:
-  - C:\"Program Files (x86)"\"Microsoft Visual Studio 14.0"\VC\vcvarsall.bat %platform%
-  - set PATH=c:\gnuwin32\bin;%PATH%
-#   - appveyor DownloadFile http://gnuwin32.sourceforge.net/downlinks/make-bin-zip.php -FileName make.zip
-#   - unzip make.zip -d c:\gnuwin32\
+  - C:\"Program Files (x86)"\"%VSTUDIO_VERS%"\VC\vcvarsall.bat %platform%
+  - set PATH=C:\projects\deps\ninja;C:\gnuwin32\bin;%PATH%
+  - |-
+    if exist "C:\projects\deps\ninja\" set GETNINJA=rem
+    if not "%CMAKE_GEN%"=="Ninja" set GETNINJA=rem
+    %GETNINJA% appveyor DownloadFile "https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip" -FileName ninja.zip
+    %GETNINJA% 7z x ninja.zip -oC:\projects\deps\ninja > nul
+    %GETNINJA% ninja --version
 
 build_script:
   - tools\packaging\cpt.py ^
@@ -43,7 +55,7 @@ build_script:
         --with-cling-url=https://github.com/%APPVEYOR_REPO_NAME% ^
         --with-clang-url=http://root.cern.ch/git/clang.git ^
         --with-llvm-url=http://root.cern.ch/git/llvm.git ^
-        --with-cmake-flags="-G\"Visual Studio 14 2015 Win64\"" ^
+        --with-cmake-flags="-DLLVM_OPTIMIZED_TABLEGEN=ON -G\"%CMAKE_GEN%\"" ^
         --skip-cleanup
 
 init:

--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -538,10 +538,7 @@ def compile(arg, build_libcpp):
 
     if not CLING_BRANCH:
         box_draw("Install compiled binaries to prefix (using %d cores)" % build.cores)
-        if build.win32:
-            build.make('INSTALL')
-        else:
-            build.make('install', 'prefix=%s' % TMP_PREFIX)
+        build.make('install')
 
     if TRAVIS_BUILD_DIR:
         ### Run cling once, dumping the include paths, helps debug issues


### PR DESCRIPTION
Seemed as it exposed the CMake error on Windows it might be nice to also build with it on Appveyor.
I have no real preference if Appveyor builds with Ninja in addition to, replacing VStudio generator, or not at all.
