### PR TITLE
fix path to jupyter kernel install

### DIFF
--- a/tools/Jupyter/README.md
+++ b/tools/Jupyter/README.md
@@ -9,7 +9,7 @@ Requires ipykernel ≥ 4.0
 To install the kernel with sources in src/tools/cling:
 
     export PATH=/cling-install-prefix/bin:$PATH
-    cd /cling-install-prefix/share/cling/Jupyter/kernel
+    cd /cling-install-prefix/tools/Jupyter/kernel
 
     pip install -e .
     # or: pip3 install -e .


### PR DESCRIPTION
This fixes a wrong path in the `README.md` documentation of the Jupyter kernel in cling. The kernels are located in `.../tools/Jupyter` not in `.../share/cling`.

This was introduced with the following [commit](https://github.com/root-project/cling/commit/112370dc17a0c977e1e023a53d9d449233f55e13).