### PR TITLE
Fix dereferencing NULL and writing to freed memory.

### DIFF
--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -126,6 +126,8 @@ namespace cling {
       kExeCompilationError,
       ///\brief The function is not known.
       kExeUnkownFunction,
+      ///\brief The Transaction had no module (probably an error in CodeGen).
+      kExeNoModule,
 
       ///\brief Number of possible results.
       kNumExeResults

--- a/lib/Interpreter/IncrementalParser.cpp
+++ b/lib/Interpreter/IncrementalParser.cpp
@@ -508,10 +508,12 @@ namespace cling {
       if (!T->getParent()) {
         if (m_Interpreter->executeTransaction(*T)
             >= Interpreter::kExeFirstError) {
-          // Roll back on error in initializers
-          //assert(0 && "Error on inits.");
+          // Roll back on error in initializers.
+          // T maybe pointing to freed memory after this call:
+          // Interpreter::unload
+          //   IncrementalParser::deregisterTransaction
+          //     TransactionPool::releaseTransaction
           m_Interpreter->unload(*T);
-          T->setState(Transaction::kRolledBackWithErrors);
           return;
         }
       }


### PR DESCRIPTION
In certain circumstances on failure cling will try to dereference null.
In the same and additional circumstances it attempts to write to freed memory.