### PR TITLE
Add pkg-config support

### DIFF
--- a/tools/packaging/cling.pc
+++ b/tools/packaging/cling.pc
@@ -1,0 +1,10 @@
+prefix=/opt/cling
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: cling
+Description: Interactive C++ interpreter
+Version: 0.4~dev
+Libs: -L${libdir} -lcling -lclingInterpreter -lclingMetaProcessor -lclingUserInterface -lclingUtils
+Cflags: -I${includedir} -I${includedir}/cling/UserInterface -fno-rtti


### PR DESCRIPTION
Note:
- This pc file expects that cling is installed to /opt/cling. This is true for AUR package, but might be false for other releases.
- Maybe tools/packaging isn't the best place for this file.