### PR TITLE
Fix and expand string type caching.

### DIFF
--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -48,6 +48,7 @@ namespace clang {
   class Sema;
   class SourceLocation;
   class SourceManager;
+  class Type;
   class PresumedLoc;
 }
 
@@ -195,6 +196,12 @@ namespace cling {
     ///\brief Information about the last stored states through .storeState
     ///
     mutable std::vector<ClangInternalState*> m_StoredStates;
+
+    enum {
+      kStdStringTransaction = 0, // Transaction known to contain std::string
+      kNumTransactions
+    };
+    mutable const Transaction* m_CachedTrns[kNumTransactions] = {};
 
     ///\brief Worker function, building block for interpreter's public
     /// interfaces.
@@ -689,6 +696,12 @@ namespace cling {
     ///\brief Returns the current or last Transaction.
     ///
     const Transaction* getLatestTransaction() const;
+
+    ///\brief Returns a reference to a Transaction known to contain std::string.
+    ///
+    const Transaction*& getStdStringTransaction() const {
+      return m_CachedTrns[kStdStringTransaction];
+    }
 
     ///\brief Compile extern "C" function and return its address.
     ///

--- a/include/cling/Interpreter/LookupHelper.h
+++ b/include/cling/Interpreter/LookupHelper.h
@@ -40,17 +40,26 @@ namespace cling {
   /// Sema and Preprocessor objects.
   ///
   class LookupHelper {
-  private:
-    std::unique_ptr<clang::Parser> m_Parser;
-    Interpreter* m_Interpreter; // we do not own.
-    const clang::Type* m_StringTy;
   public:
-
+    enum StringType {
+      kStdString,
+      kWCharString,
+      kUTF16Str,
+      kUTF32Str,
+      kNumCachedStrings,
+      kNotAString = kNumCachedStrings,
+    };
     enum DiagSetting {
       NoDiagnostics,
       WithDiagnostics
     };
 
+  private:
+    std::unique_ptr<clang::Parser> m_Parser;
+    Interpreter* m_Interpreter; // we do not own.
+    const clang::Type* m_StringTy[kNumCachedStrings];
+
+  public:
     LookupHelper(clang::Parser* P, Interpreter* interp);
     ~LookupHelper();
 
@@ -224,9 +233,8 @@ namespace cling {
     bool hasFunction(const clang::Decl* scopeDecl, llvm::StringRef funcName,
                      DiagSetting diagOnOff) const;
 
-
-    ///\brief Retrieve the QualType of `std::string`.
-    const clang::Type* getStringType();
+    ///\brief Retrieve the StringType of given Type.
+     StringType getStringType(const clang::Type* Type);
   };
 
 } // end namespace

--- a/include/cling/Interpreter/LookupHelper.h
+++ b/include/cling/Interpreter/LookupHelper.h
@@ -33,6 +33,8 @@ namespace llvm {
 
 namespace cling {
   class Interpreter;
+  class Transaction;
+
   ///\brief Reflection information query interface. The class performs lookups
   /// in the currently loaded information in the AST, using the same Parser,
   /// Sema and Preprocessor objects.
@@ -225,7 +227,6 @@ namespace cling {
 
     ///\brief Retrieve the QualType of `std::string`.
     const clang::Type* getStringType();
-
   };
 
 } // end namespace

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -1275,6 +1275,14 @@ namespace cling {
       }
     }
 
+    // Clear any cached transaction states.
+    for (unsigned i = 0; i < kNumTransactions; ++i) {
+      if (m_CachedTrns[i] == &T) {
+        m_CachedTrns[i] = nullptr;
+        break;
+      }
+    }
+
     if (InterpreterCallbacks* callbacks = getCallbacks())
       callbacks->TransactionUnloaded(T);
     if (m_Executor) { // we also might be in fsyntax-only mode.

--- a/lib/Interpreter/LookupHelper.cpp
+++ b/lib/Interpreter/LookupHelper.cpp
@@ -1899,8 +1899,12 @@ namespace cling {
   }
 
   const Type* LookupHelper::getStringType() {
-    if (!m_StringTy)
-      m_StringTy = findType("std::string", WithDiagnostics).getTypePtr();
+    const Transaction*& Cache = m_Interpreter->getStdStringTransaction();
+    if (!Cache || !m_StringTy) {
+      QualType Qt = findType("std::string", WithDiagnostics);
+      if ((m_StringTy = Qt.isNull() ? nullptr : Qt.getTypePtr()))
+        Cache = m_Interpreter->getLatestTransaction();
+    }
     return m_StringTy;
   }
 

--- a/lib/Interpreter/ValuePrinter.cpp
+++ b/lib/Interpreter/ValuePrinter.cpp
@@ -776,9 +776,11 @@ static std::string printUnpackedClingValue(const Value &V) {
   } else if (clang::CXXRecordDecl *CXXRD = Ty->getAsCXXRecordDecl()) {
     if (CXXRD->isLambda())
       return printAddress(V.getPtr(), '@');
-    LookupHelper& LH= V.getInterpreter()->getLookupHelper();
-    if (C.hasSameType(CXXRD->getTypeForDecl(), LH.getStringType()))
-      return executePrintValue<std::string>(V, *(std::string*)V.getPtr());
+    if (const clang::Type* StrTy =
+            V.getInterpreter()->getLookupHelper().getStringType()) {
+      if (C.hasSameType(CXXRD->getTypeForDecl(), StrTy))
+        return executePrintValue<std::string>(V, *(std::string*)V.getPtr());
+    }
   } else if (const clang::BuiltinType *BT
       = llvm::dyn_cast<clang::BuiltinType>(Td.getCanonicalType().getTypePtr())) {
     switch (BT->getKind()) {

--- a/lib/Interpreter/ValuePrinter.cpp
+++ b/lib/Interpreter/ValuePrinter.cpp
@@ -754,6 +754,22 @@ static std::string printFunctionValue(const Value &V, const void *ptr, clang::Qu
   return o.str();
 }
 
+static std::string printStringType(const Value &V, const clang::Type* Type) {
+  switch (V.getInterpreter()->getLookupHelper().getStringType(Type)) {
+    case LookupHelper::kStdString:
+      return executePrintValue<std::string>(V, *(std::string*)V.getPtr());
+    case LookupHelper::kWCharString:
+      return executePrintValue<std::wstring>(V, *(std::wstring*)V.getPtr());
+    case LookupHelper::kUTF16Str:
+      return executePrintValue<std::u16string>(V, *(std::u16string*)V.getPtr());
+    case LookupHelper::kUTF32Str:
+      return executePrintValue<std::u32string>(V, *(std::u32string*)V.getPtr());
+    default:
+      break;
+  }
+  return "";
+}
+
 static std::string printUnpackedClingValue(const Value &V) {
   // Find the Type for `std::string`. We are guaranteed to have that declared
   // when this function is called; RuntimePrintValue.h #includes it.
@@ -776,11 +792,10 @@ static std::string printUnpackedClingValue(const Value &V) {
   } else if (clang::CXXRecordDecl *CXXRD = Ty->getAsCXXRecordDecl()) {
     if (CXXRD->isLambda())
       return printAddress(V.getPtr(), '@');
-    if (const clang::Type* StrTy =
-            V.getInterpreter()->getLookupHelper().getStringType()) {
-      if (C.hasSameType(CXXRD->getTypeForDecl(), StrTy))
-        return executePrintValue<std::string>(V, *(std::string*)V.getPtr());
-    }
+
+    std::string Str = printStringType(V, CXXRD->getTypeForDecl());
+    if (!Str.empty())
+      return Str;
   } else if (const clang::BuiltinType *BT
       = llvm::dyn_cast<clang::BuiltinType>(Td.getCanonicalType().getTypePtr())) {
     switch (BT->getKind()) {


### PR DESCRIPTION
cb2384f fixed a bug using a static to cache the type of a std:string; however, if the Transaction owning the 'std::string' type is undone this local variable will then point to invalid memory.

Also adds caching of other std::strings types (wchar, u16, and u32).