### PR TITLE
Refactor specializations of executePrintValue.

### DIFF
--- a/lib/Interpreter/ValuePrinter.cpp
+++ b/lib/Interpreter/ValuePrinter.cpp
@@ -208,9 +208,6 @@ static std::string printQualType(clang::ASTContext& Ctx, clang::QualType QT) {
   return ValueTyStr + ")";
 }
 
-} // anonymous namespace
-
-
 static std::string printAddress(const void* Ptr, const char Prfx = 0) {
   if (!Ptr)
     return kNullPtrStr;
@@ -223,6 +220,8 @@ static std::string printAddress(const void* Ptr, const char Prfx = 0) {
     Strm << kInvalidAddr;
   return Strm.str();
 }
+
+} // anonymous namespace
 
 namespace cling {
 
@@ -581,6 +580,7 @@ namespace cling {
   }
 } // end namespace cling
 
+namespace {
 
 template<typename T, bool> struct ExecutePrintValue;
 
@@ -832,6 +832,8 @@ static std::string printUnpackedClingValue(const Value &V) {
   // Ty->isObjCObjectPointerType()
   return ExecutePrintValue<void*, false>()(V, V.getPtr());
 }
+
+} // anonymous namespace
 
 namespace cling {
   // cling::Value


### PR DESCRIPTION
The templated variants of ExecutePrintValue can cause multiple instantiations of code that is not dependent on any template parameter, as well a lot of duplicate/dependent function signatures.