### PR TITLE
Destroy cling::Value elements in reverse order of construction.

### DIFF
--- a/lib/Interpreter/Value.cpp
+++ b/lib/Interpreter/Value.cpp
@@ -86,9 +86,11 @@ namespace {
       assert (m_RefCnt > 0 && "Reference count is already zero.");
       if (--m_RefCnt == 0) {
         if (m_DtorFunc) {
-          char* payload = getPayload();
-          for (size_t el = 0; el < m_NElements; ++el)
-            (*m_DtorFunc)(payload + el * m_AllocSize / m_NElements);
+          assert(m_NElements && "No elements!");
+          char* Payload = getPayload();
+          const auto Skip = m_AllocSize / m_NElements;
+          while (m_NElements-- != 0)
+            (*m_DtorFunc)(Payload + m_NElements * Skip);
         }
         delete [] (char*)this;
       }

--- a/test/Interfaces/evaluate.C
+++ b/test/Interfaces/evaluate.C
@@ -208,6 +208,18 @@ gCling->evaluate("arrV", V);
 
 V // CHECK-NEXT: (cling::Value &) boxes [(Tracer [3]) { @{{.*}}, @{{.*}}, @{{.*}} }]
 
+// Explicitly destory the copies
+V = cling::Value()
+//CHECK-NEXT: MADE+{10}:dtor
+//CHECK-NEXT: MADE+{9}:dtor
+//CHECK-NEXT: MADE+{8}:dtor
+//CHECK-NEXT: (cling::Value &) <<<invalid>>> @0x{{.*}}
+
+gCling->evaluate("arrV", V);
+//CHECK-NEXT: MADE+{11}:copy
+//CHECK-NEXT: MADE+{12}:copy
+//CHECK-NEXT: MADE+{13}:copy
+
 // Destruct the variables with static storage:
 // Destruct arrV:
 //CHECK-NEXT: MADE{7}:dtor
@@ -217,7 +229,7 @@ V // CHECK-NEXT: (cling::Value &) boxes [(Tracer [3]) { @{{.*}}, @{{.*}}, @{{.*}
 // CHECK-NEXT: VAR{3}:dtor
 // CHECK-NEXT: REF{1}:dtor
 
-//CHECK-NEXT: MADE+{8}:dtor
-//CHECK-NEXT: MADE+{9}:dtor
-//CHECK-NEXT: MADE+{10}:dtor
-
+// V going out of scope
+//CHECK-NEXT: MADE+{13}:dtor
+//CHECK-NEXT: MADE+{12}:dtor
+//CHECK-NEXT: MADE+{11}:dtor

--- a/test/Interfaces/evaluate.C
+++ b/test/Interfaces/evaluate.C
@@ -113,14 +113,17 @@ V // CHECK: (cling::Value &) boxes [(long double) 17.42{{[0-9]*}}L]
 extern "C" int printf(const char*,...);
 struct Tracer {
   std::string Content;
+  int Instance;
   static int InstanceCount;
-  Tracer(const char* str): Content(str) { ++InstanceCount; dump("ctor"); }
-  Tracer(const Tracer& o): Content(o.Content + "+") {
-    ++InstanceCount; dump("copy");
+  Tracer(const char* str): Content(str), Instance(++InstanceCount) {
+    dump("ctor");
   }
-  ~Tracer() {--InstanceCount; dump("dtor");}
+  Tracer(const Tracer& o): Content(o.Content + "+"), Instance(++InstanceCount) {
+    dump("copy");
+  }
+  ~Tracer() { dump("dtor");}
   std::string asStr() const {
-    return Content + "{" + (char)('0' + InstanceCount) + "}";
+    return Content + "{" + std::to_string(Instance) + "}";
   }
   void dump(const char* tag) { printf("%s:%s\n", asStr().c_str(), tag); }
 };
@@ -176,32 +179,32 @@ Tracer RT("VAR"); // CHECK-NEXT: VAR{3}:ctor
 gCling->evaluate("RT", V); // should not call any ctor!
 printf("RT done\n"); //CHECK-NEXT: RT done
 V // CHECK-NEXT: (cling::Value &) boxes [(Tracer &) @{{.*}}]
-dumpTracerSVR(V); // CHECK-NEXT: VAR{2}:dump
+dumpTracerSVR(V); // CHECK-NEXT: VAR{3}:dump
 
 // The following creates a copy, explicitly. This temporary object is then put
 // into the Value.
 //
 gCling->evaluate("(Tracer)RT", V);
 // Copies RT:
-//CHECK-NEXT: VAR+{3}:copy
+//CHECK-NEXT: VAR+{4}:copy
 printf("(Tracer)RT done\n"); //CHECK-NEXT: RT done
 V // CHECK-NEXT: (cling::Value &) boxes [(Tracer) @{{.*}}]
-dumpTracerSVR(V); // CHECK-NEXT: VAR+{3}:dump
+dumpTracerSVR(V); // CHECK-NEXT: VAR+{4}:dump
 
 // Check eval of array var
 Tracer arrV[] = {ObjMaker(), ObjMaker(), ObjMaker()};
 // The array is built:
-//CHECK-NEXT: MADE{4}:ctor
 //CHECK-NEXT: MADE{5}:ctor
 //CHECK-NEXT: MADE{6}:ctor
+//CHECK-NEXT: MADE{7}:ctor
 
 gCling->evaluate("arrV", V);
 // Now V gets destructed...
-//CHECK-NEXT: VAR+{5}:dtor
+//CHECK-NEXT: VAR+{4}:dtor
 // ...and the elements are copied:
-//CHECK-NEXT: MADE+{6}:copy
-//CHECK-NEXT: MADE+{7}:copy
 //CHECK-NEXT: MADE+{8}:copy
+//CHECK-NEXT: MADE+{9}:copy
+//CHECK-NEXT: MADE+{10}:copy
 
 V // CHECK-NEXT: (cling::Value &) boxes [(Tracer [3]) { @{{.*}}, @{{.*}}, @{{.*}} }]
 
@@ -211,9 +214,10 @@ V // CHECK-NEXT: (cling::Value &) boxes [(Tracer [3]) { @{{.*}}, @{{.*}}, @{{.*}
 //CHECK-NEXT: MADE{6}:dtor
 //CHECK-NEXT: MADE{5}:dtor
 
-// CHECK-NEXT: VAR{4}:dtor
-// CHECK-NEXT: REF{3}:dtor
+// CHECK-NEXT: VAR{3}:dtor
+// CHECK-NEXT: REF{1}:dtor
 
-//CHECK-NEXT: MADE+{2}:dtor
-//CHECK-NEXT: MADE+{1}:dtor
-//CHECK-NEXT: MADE+{0}:dtor
+//CHECK-NEXT: MADE+{8}:dtor
+//CHECK-NEXT: MADE+{9}:dtor
+//CHECK-NEXT: MADE+{10}:dtor
+


### PR DESCRIPTION
Matches C++ better, and fixes a problem where a constructed array element can reference an earlier element already destructed.