### PR TITLE
Have MetaProcessor::process take an llvm::StringRef.

### DIFF
--- a/include/cling/MetaProcessor/MetaProcessor.h
+++ b/include/cling/MetaProcessor/MetaProcessor.h
@@ -114,7 +114,7 @@ namespace cling {
     /// have in case of multi input mode.
     ///\returns -1 if quit was requiested.
     ///
-    int process(const char* input_line,
+    int process(llvm::StringRef input_line,
                 Interpreter::CompilationResult& compRes,
                 cling::Value* result = nullptr,
                 bool disableValuePrinting = false);

--- a/lib/MetaProcessor/MetaProcessor.cpp
+++ b/lib/MetaProcessor/MetaProcessor.cpp
@@ -291,7 +291,7 @@ namespace cling {
   MetaProcessor::~MetaProcessor() {
   }
 
-  int MetaProcessor::process(const char* input_text,
+  int MetaProcessor::process(llvm::StringRef input_line,
                              Interpreter::CompilationResult& compRes,
                              Value* result,
                              bool disableValuePrinting /* = false */) {
@@ -302,14 +302,13 @@ namespace cling {
 
     if (expectedIndent)
       compRes = Interpreter::kMoreInputExpected;
-    if (!input_text || !input_text[0]) {
-      // nullptr / empty string, nothing to do.
+
+    if (input_line.empty() ||
+        (input_line.size() == 1 && input_line.front() == '\n')) {
+      // just a blank line, nothing to do.
       return expectedIndent;
     }
-    std::string input_line(input_text);
-    if (input_line == "\n") { // just a blank line, nothing to do.
-      return expectedIndent;
-    }
+
     //  Check for and handle meta commands.
     m_MetaParser->enterNewInputLine(input_line);
     MetaSema::ActionResult actionResult = MetaSema::AR_Success;
@@ -477,7 +476,7 @@ namespace cling {
       std::string line;
       std::stringstream ss(content);
       while (std::getline(ss, line, '\n')) {
-        rslt = process(line.c_str(), ret, result);
+        rslt = process(line, ret, result);
         if (ret == Interpreter::kFailure)
           break;
       }

--- a/lib/UserInterface/UserInterface.cpp
+++ b/lib/UserInterface/UserInterface.cpp
@@ -95,7 +95,7 @@ namespace cling {
         }
 
         cling::Interpreter::CompilationResult compRes;
-        const int indent = m_MetaProcessor->process(Line.c_str(), compRes);
+        const int indent = m_MetaProcessor->process(Line, compRes);
 
         // Quit requested?
         if (indent < 0)

--- a/tools/driver/cling.cpp
+++ b/tools/driver/cling.cpp
@@ -120,14 +120,14 @@ int main( int argc, char **argv ) {
           // TODO: Check whether the filename specified after #! is the current
           // executable.
           while (std::getline(File, Line)) {
-            Ui.getMetaProcessor()->process(Line.c_str(), Result, 0);
+            Ui.getMetaProcessor()->process(Line, Result, 0);
           }
           continue;
         }
         Cmd += ".x ";
       }
       Cmd += Input;
-      Ui.getMetaProcessor()->process(Cmd.c_str(), Result, 0);
+      Ui.getMetaProcessor()->process(Cmd, Result, 0);
     }
   }
   else {


### PR DESCRIPTION
Remove unnecessary std::string -> const char* -> std::string conversions.