### PR TITLE
Refactor pragma handling.

### DIFF
--- a/lib/Interpreter/ClingPragmas.cpp
+++ b/lib/Interpreter/ClingPragmas.cpp
@@ -18,6 +18,7 @@
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/LiteralSupport.h"
 #include "clang/Lex/Token.h"
 #include "clang/Parse/Parser.h"
 #include "clang/Parse/ParseDiagnostic.h"
@@ -45,20 +46,67 @@ namespace {
       }
     };
 
-    void ReportCommandErr(Preprocessor& PP, const Token& Tok) {
-      PP.Diag(Tok.getLocation(), diag::err_expected)
-        << "load, add_library_path, or add_include_path";
-    }
-
     enum {
       kLoadFile,
       kAddLibrary,
       kAddInclude,
       // Put all commands that expand environment variables above this
       kExpandEnvCommands,
-      kOptimize = kExpandEnvCommands,
+
+      // Put all commands that only take string literals above this
+      kArgumentsAreLiterals,
+
+      kOptimize,
       kInvalidCommand,
     };
+
+    bool GetNextLiteral(Preprocessor& PP, Token& Tok, std::string& Literal,
+                        unsigned Cmd, const char* firstTime = nullptr) const {
+      Literal.clear();
+
+      PP.Lex(Tok);
+      if (Tok.isLiteral()) {
+        if (clang::tok::isStringLiteral(Tok.getKind())) {
+          SmallVector<Token, 1> StrToks(1, Tok);
+          StringLiteralParser LitParse(StrToks, PP);
+          if (!LitParse.hadError)
+            Literal = LitParse.GetString();
+        } else {
+          llvm::SmallString<64> Buffer;
+          Literal = PP.getSpelling(Tok, Buffer).str();
+        }
+      }
+      else if (Tok.is(tok::comma))
+        return GetNextLiteral(PP, Tok, Literal, Cmd);
+      else if (firstTime) {
+        if (Tok.is(tok::l_paren)) {
+          if (Cmd < kArgumentsAreLiterals) {
+            if (!PP.LexStringLiteral(Tok, Literal, firstTime,
+                                     false /*allowMacroExpansion*/)) {
+              // already diagnosed.
+              return false;
+            }
+          } else {
+            PP.Lex(Tok);
+            llvm::SmallString<64> Buffer;
+            Literal = PP.getSpelling(Tok, Buffer).str();
+          }
+        }
+      }
+
+      if (Literal.empty())
+        return false;
+
+      if (Cmd < kExpandEnvCommands)
+        utils::ExpandEnvVars(Literal);
+
+      return true;
+    }
+
+    void ReportCommandErr(Preprocessor& PP, const Token& Tok) {
+      PP.Diag(Tok.getLocation(), diag::err_expected)
+        << "load, add_library_path, or add_include_path";
+    }
 
     int GetCommand(const StringRef CommandStr) {
       if (CommandStr == "load")
@@ -71,7 +119,72 @@ namespace {
         return kOptimize;
       return kInvalidCommand;
     }
-    
+
+    void LoadCommand(Preprocessor& PP, Token& Tok, std::string Literal) {
+      // No need to load libraries when not executing anything.
+      if (m_Interp.isInSyntaxOnlyMode())
+        return;
+
+      // Need to parse them all until the end to handle the possible
+      // #include stements that will be generated
+      std::vector<std::string> Files;
+      Files.push_back(std::move(Literal));
+      while (GetNextLiteral(PP, Tok, Literal, kLoadFile))
+        Files.push_back(std::move(Literal));
+      
+      clang::Parser& P = m_Interp.getParser();
+      Parser::ParserCurTokRestoreRAII savedCurToken(P);
+      // After we have saved the token reset the current one to something
+      // which is safe (semi colon usually means empty decl)
+      Token& CurTok = const_cast<Token&>(P.getCurToken());
+      CurTok.setKind(tok::semi);
+      
+      Preprocessor::CleanupAndRestoreCacheRAII cleanupRAII(PP);
+      // We can't PushDeclContext, because we go up and the routine that
+      // pops the DeclContext assumes that we drill down always.
+      // We have to be on the global context. At that point we are in a
+      // wrapper function so the parent context must be the global.
+      TranslationUnitDecl* TU =
+      m_Interp.getCI()->getASTContext().getTranslationUnitDecl();
+      Sema::ContextAndScopeRAII pushedDCAndS(m_Interp.getSema(),
+                                            TU, m_Interp.getSema().TUScope);
+      Interpreter::PushTransactionRAII pushedT(&m_Interp);
+
+      for (std::string& File : Files) {
+        if (m_Interp.loadFile(File, true) != Interpreter::kSuccess)
+          return;
+      }
+    }
+
+    void OptimizeCommand(const char* Str) {
+      char* ConvEnd = nullptr;
+      int OptLevel = std::strtol(Str, &ConvEnd, 10 /*base*/);
+      if (!ConvEnd || ConvEnd == Str) {
+        cling::errs() << "cling::PHOptLevel: "
+          "missing or non-numerical optimization level.\n" ;
+        return;
+      }
+      auto T = const_cast<Transaction*>(m_Interp.getCurrentTransaction());
+      assert(T && "Parsing code without transaction!");
+      // The topmost Transaction drives the jitting.
+      T = T->getTopmostParent();
+      CompilationOptions& CO = T->getCompilationOpts();
+      if (CO.OptLevel != m_Interp.getDefaultOptLevel()) {
+        // Another #pragma already changed the opt level, a conflict that
+        // cannot be resolve here.  Mention and keep the lower one.
+        cling::errs() << "cling::PHOptLevel: "
+          "conflicting `#pragma cling optimize` directives: "
+          "was already set to " << CO.OptLevel << '\n';
+        if (CO.OptLevel > OptLevel) {
+          CO.OptLevel = OptLevel;
+          cling::errs() << "Setting to lower value of " << OptLevel << '\n';
+        } else {
+          cling::errs() << "Ignoring higher value of " << OptLevel << '\n';
+        }
+      } else
+        CO.OptLevel = OptLevel;
+  }
+
   public:
     ClingPragmaHandler(Interpreter& interp):
       PragmaHandler("cling"), m_Interp(interp) {}
@@ -84,101 +197,44 @@ namespace {
       PP.Lex(Tok);
       SkipToEOD OnExit(PP, Tok);
 
+      // #pragma cling(load, "A")
+      if (Tok.is(tok::l_paren))
+        PP.Lex(Tok);
+
       if (Tok.isNot(tok::identifier)) {
         ReportCommandErr(PP, Tok);
         return;
       }
 
       const StringRef CommandStr = Tok.getIdentifierInfo()->getName();
-      const int Command = GetCommand(CommandStr);
+      const unsigned Command = GetCommand(CommandStr);
+      assert(Command != kArgumentsAreLiterals && Command != kExpandEnvCommands);
       if (Command == kInvalidCommand) {
         ReportCommandErr(PP, Tok);
         return;
       }
 
-      PP.Lex(Tok);
-      if (Tok.isNot(tok::l_paren)) {
-        PP.Diag(Tok.getLocation(), diag::err_expected_lparen_after)
-                << CommandStr;
-        return;
-      }
-
       std::string Literal;
-      if (Command < kExpandEnvCommands) {
-        if (!PP.LexStringLiteral(Tok, Literal, CommandStr.str().c_str(),
-                                 false /*allowMacroExpansion*/)) {
-          // already diagnosed.
-          return;
-        }
-        utils::ExpandEnvVars(Literal);
-      } else {
-        PP.Lex(Tok);
-        llvm::SmallString<64> Buffer;
-        Literal = PP.getSpelling(Tok, Buffer).str();
+      if (!GetNextLiteral(PP, Tok, Literal, Command, CommandStr.data())) {
+        PP.Diag(Tok.getLocation(), diag::err_expected_after)
+          << CommandStr << "argument";
+        return;
       }
 
       switch (Command) {
         case kLoadFile:
-          if (!m_Interp.isInSyntaxOnlyMode()) {
-            // No need to load libraries if we're not executing anything.
+        return LoadCommand(PP, Tok, std::move(Literal));
+        case kOptimize:
+          return OptimizeCommand(Literal.c_str());
 
-            clang::Parser& P = m_Interp.getParser();
-            Parser::ParserCurTokRestoreRAII savedCurToken(P);
-            // After we have saved the token reset the current one to something
-            // which is safe (semi colon usually means empty decl)
-            Token& CurTok = const_cast<Token&>(P.getCurToken());
-            CurTok.setKind(tok::semi);
-            
-            Preprocessor::CleanupAndRestoreCacheRAII cleanupRAII(PP);
-            // We can't PushDeclContext, because we go up and the routine that
-            // pops the DeclContext assumes that we drill down always.
-            // We have to be on the global context. At that point we are in a
-            // wrapper function so the parent context must be the global.
-            TranslationUnitDecl* TU =
-            m_Interp.getCI()->getASTContext().getTranslationUnitDecl();
-            Sema::ContextAndScopeRAII pushedDCAndS(m_Interp.getSema(),
-                                                  TU, m_Interp.getSema().TUScope);
-            Interpreter::PushTransactionRAII pushedT(&m_Interp);
-            
-            m_Interp.loadFile(Literal, true /*allowSharedLib*/);
-          }
+        default:
+          do {
+            if (Command == kAddLibrary)
+              m_Interp.getOptions().LibSearchPath.push_back(std::move(Literal));
+            else if (Command == kAddInclude)
+              m_Interp.AddIncludePath(Literal);
+          } while (GetNextLiteral(PP, Tok, Literal, Command));
           break;
-        case kAddLibrary:
-          m_Interp.getOptions().LibSearchPath.push_back(std::move(Literal));
-          break;
-        case kAddInclude:
-          m_Interp.AddIncludePath(Literal);
-          break;
-
-        case kOptimize: {
-          char* ConvEnd = nullptr;
-          int OptLevel = std::strtol(Literal.c_str(), &ConvEnd, 10 /*base*/);
-          if (!ConvEnd || ConvEnd == Literal.c_str()) {
-            cling::errs() << "cling::PHOptLevel: "
-              "missing or non-numerical optimization level.\n" ;
-            return;
-          }
-          auto T = const_cast<Transaction*>(m_Interp.getCurrentTransaction());
-          assert(T && "Parsing code without transaction!");
-          // The topmost Transaction drives the jitting.
-          T = T->getTopmostParent();
-          CompilationOptions& CO = T->getCompilationOpts();
-          if (CO.OptLevel != m_Interp.getDefaultOptLevel()) {
-            // Another #pragma already changed the opt level, a conflict that
-            // cannot be resolve here.  Mention and keep the lower one.
-            cling::errs() << "cling::PHOptLevel: "
-              "conflicting `#pragma cling optimize` directives: "
-              "was already set to " << CO.OptLevel << '\n';
-            if (CO.OptLevel > OptLevel) {
-              CO.OptLevel = OptLevel;
-              cling::errs() << "Setting to lower value of " << OptLevel << '\n';
-            } else {
-              cling::errs() << "Ignoring higher value of " << OptLevel << '\n';
-            }
-          } else {
-            CO.OptLevel = OptLevel;
-          }
-        }
       }
     }
   };

--- a/test/Pragmas/P0.h
+++ b/test/Pragmas/P0.h
@@ -1,0 +1,1 @@
+const char* ValueA = "ValueA";

--- a/test/Pragmas/P0.h P1.h P2.h
+++ b/test/Pragmas/P0.h P1.h P2.h
@@ -1,0 +1,1 @@
+const char* ValueD = "ValueD";

--- a/test/Pragmas/P1.h
+++ b/test/Pragmas/P1.h
@@ -1,0 +1,1 @@
+const char* ValueB = "ValueB";

--- a/test/Pragmas/P2.h
+++ b/test/Pragmas/P2.h
@@ -1,0 +1,1 @@
+const char* ValueC = "ValueC";

--- a/test/Pragmas/multiArgument.C
+++ b/test/Pragmas/multiArgument.C
@@ -8,6 +8,10 @@
 
 // RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
 
+// FIXME: When printing can be properly unloaded don't force it here
+"BEGIN"
+// CHECK: (const char [6]) "BEGIN"
+
 #pragma cling load("P0.h", "P1.h","P2.h")
 
 ValueA
@@ -20,6 +24,11 @@ ValueC
 // CHECK-NEXT: (const char *) "ValueC"
 
 .undo
+.undo
+.undo
+.undo
+
+// FIXME: When print Transactions are properly parenteted remove these
 .undo
 .undo
 .undo
@@ -37,6 +46,11 @@ ValueC
 // CHECK-NEXT: (const char *) "ValueC"
 
 .undo
+.undo
+.undo
+.undo
+
+// FIXME: When print Transactions are properly parenteted remove these
 .undo
 .undo
 .undo

--- a/test/Pragmas/multiArgument.C
+++ b/test/Pragmas/multiArgument.C
@@ -1,0 +1,61 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -I%S -Xclang -verify 2>&1 | FileCheck %s
+
+#pragma cling load("P0.h", "P1.h","P2.h")
+
+ValueA
+// CHECK-NEXT: (const char *) "ValueA"
+
+ValueB
+// CHECK-NEXT: (const char *) "ValueB"
+
+ValueC
+// CHECK-NEXT: (const char *) "ValueC"
+
+.undo
+.undo
+.undo
+.undo
+
+ValueA // expected-error {{use of undeclared identifier 'ValueA'}}
+
+#pragma cling load "P0.h" "P1.h" "P2.h"
+ValueA
+// CHECK-NEXT: (const char *) "ValueA"
+
+ValueB
+// CHECK-NEXT: (const char *) "ValueB"
+
+ValueC
+// CHECK-NEXT: (const char *) "ValueC"
+
+.undo
+.undo
+.undo
+.undo
+
+ValueB // expected-error {{use of undeclared identifier 'ValueB'}}
+
+#pragma cling(load, "P0.h", "P1.h", "P2.h")
+ValueA
+// CHECK-NEXT: (const char *) "ValueA"
+
+ValueB
+// CHECK-NEXT: (const char *) "ValueB"
+
+ValueC
+// CHECK-NEXT: (const char *) "ValueC"
+
+
+#pragma cling load "P0.h P1.h P2.h"
+ValueD
+// CHECK-NEXT: (const char *) "ValueD"
+
+.q

--- a/test/Pragmas/opt.C
+++ b/test/Pragmas/opt.C
@@ -12,29 +12,41 @@ extern "C" int printf(const char*,...);
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Transaction.h"
 
-gCling->getDefaultOptLevel() // CHECK: (int) 2
-(int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel // CHECK-NEXT: (int) 2
+gCling->getDefaultOptLevel()
+// CHECK: (int) 2
+
+(int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel
+// CHECK-NEXT: (int) 2
 
 {
 #pragma cling optimize(0)
-  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel); // CHECK: Transaction OptLevel=0
+  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel);
 }
+// CHECK-NEXT: Transaction OptLevel=0
+
 {
 #pragma cling optimize(1)
-  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel); // CHECK: Transaction OptLevel=1
+  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel);
 }
+// CHECK-NEXT: Transaction OptLevel=1
 
 {
 #pragma cling optimize(2)
-  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel); // CHECK: Transaction OptLevel=2
+  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel);
 }
+// CHECK-NEXT: Transaction OptLevel=2
 
 {
 #pragma cling optimize(0)
-#pragma cling optimize(1) // CHECK-NEXT: cling::PHOptLevel: conflicting `#pragma cling optimize` directives: was already set to 0
-  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel); // CHECK: Transaction OptLevel=0
+#pragma cling optimize(1)
+  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel);
 }
-.O // CHECK-NEXT: Current cling optimization level: 2
+// CHECK-NEXT: cling::PHOptLevel: conflicting `#pragma cling optimize` directives: was already set to 0
+// CHECK-NEXT: Ignoring higher value of 1
+// CHECK-NEXT: Transaction OptLevel=0
+
+.O
+// CHECK-NEXT: Current cling optimization level: 2
 
 // No parenthesis
 {

--- a/test/Pragmas/opt.C
+++ b/test/Pragmas/opt.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
 
 extern "C" int printf(const char*,...);
 #include "cling/Interpreter/Interpreter.h"
@@ -35,3 +35,22 @@ gCling->getDefaultOptLevel() // CHECK: (int) 2
   printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel); // CHECK: Transaction OptLevel=0
 }
 .O // CHECK-NEXT: Current cling optimization level: 2
+
+// No parenthesis
+{
+#pragma cling optimize 1
+  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel);
+}
+// CHECK-NEXT: Transaction OptLevel=1
+
+// Full functional style
+{
+#pragma cling(optimize, 3)
+  printf("Transaction OptLevel=%d\n", (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel);
+}
+// CHECK-NEXT: Transaction OptLevel=3
+
+// Invalid token
+#pragma cling optimize Invalid // expected-error {{expected argument after optimize}}
+
+.q


### PR DESCRIPTION
Only allocate a single pragma handler.
Support multiple arguments and function/MS styles
```
#pragma cling load "FILE1" "FILE2" "FILE3"
#pragma cling(load, "FILE")
#pragma cling(load, "FILE1", "FILE2)
#pragma cling load("FILE1", "FILE2", "FILE3")
```

1/2 to allow running arbitrary meta-commands via **#pragma** statements.