### PR TITLE
Fix buffer overflow.

### DIFF
--- a/lib/Interpreter/IncrementalParser.cpp
+++ b/lib/Interpreter/IncrementalParser.cpp
@@ -688,7 +688,7 @@ namespace cling {
                                                    source_name.str()));
     char* MBStart = const_cast<char*>(MB->getBufferStart());
     memcpy(MBStart, input.data(), InputSize);
-    memcpy(MBStart + InputSize, "\n", 2);
+    MBStart[InputSize] = '\n';
 
     SourceManager& SM = getCI()->getSourceManager();
 


### PR DESCRIPTION
Am I reading this wrong or is a buffer of `InputSize + 1` allocated but the final memcpy is equivalent to:
```
Buf[InputSize] = '\n';
Buf[InputSize+1] = 0;
```
