### PR TITLE
Faster and more efficient to not write the lines that won’t be compared.

### DIFF
--- a/lib/Interpreter/ClangInternalState.cpp
+++ b/lib/Interpreter/ClangInternalState.cpp
@@ -164,11 +164,8 @@ namespace cling {
     differentContent(m_LookupTablesFile, m_DiffPair->m_LookupTablesFile,
                      "lookup tables", verbose, &builtinNames);
 
-    // We create a virtual file for each input line in the format input_line_N.
-    llvm::SmallVector<llvm::StringRef, 2> input_lines;
-    input_lines.push_back("input_line_[0-9].*");
     differentContent(m_IncludedFilesFile, m_DiffPair->m_IncludedFilesFile,
-                     "included files", verbose, &input_lines);
+                     "included files", verbose);
 
     differentContent(m_ASTFile, m_DiffPair->m_ASTFile, "AST", verbose);
 
@@ -263,7 +260,15 @@ namespace cling {
       // print the FileName, because semantically it is not there.
       if (!I->second)
         continue;
+
       std::string fileName(FE->getName());
+      // We create a virtual file for each input line in the format input_line_N
+      if (fileName.size() > 11 && fileName.find("input_line_") == 0 &&
+          std::find_if(fileName.begin() + 11, fileName.end(), [](char c) {
+            return !std::isdigit(c);
+          }) == fileName.end()) {
+        continue;
+      }
       if (!(fileName.compare(0, 5, "/usr/") == 0 &&
             fileName.find("/bits/") != std::string::npos) &&
           fileName.compare("-")) {


### PR DESCRIPTION
State comparison involves comparing the include file cache. Currently all input_line_X entries are ignored. As such just not writing them to disk should be more efficient than ignoring via diff.