### PR TITLE
Revert "Avoid memset by using in-class member init."

### DIFF
--- a/include/cling/Interpreter/LookupHelper.h
+++ b/include/cling/Interpreter/LookupHelper.h
@@ -57,7 +57,7 @@ namespace cling {
   private:
     std::unique_ptr<clang::Parser> m_Parser;
     Interpreter* m_Interpreter; // we do not own.
-    const clang::Type* m_StringTy[kNumCachedStrings] = {};
+    const clang::Type* m_StringTy[kNumCachedStrings];
 
   public:
     LookupHelper(clang::Parser* P, Interpreter* interp);


### PR DESCRIPTION
Add comments as to why resetting to zero is necessary.

This reverts commit 65b4cd2cc3150b4d582338cf8920d20d1416681c.