### PR TITLE
Fix crash and propogate/report errors better.

### DIFF
--- a/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -13,7 +13,6 @@
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/Value.h"
 #include "cling/Utils/AST.h"
-#include "cling/Utils/Output.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclGroup.h"
@@ -204,7 +203,7 @@ namespace {
 }
 
   Expr* ValueExtractionSynthesizer::SynthesizeSVRInit(Expr* E) {
-    if (!m_gClingVD && !FindAndCacheRuntimeDecls())
+    if (!m_gClingVD && !FindAndCacheRuntimeDecls(E))
       return nullptr;
 
     // Build a reference to gCling
@@ -407,28 +406,30 @@ namespace {
     return Call.get();
   }
 
-  static bool VSError(const char* err) {
-    cling::errs() << "ValueExtractionSynthesizer error: " << err << ".\n";
+  static bool VSError(clang::Sema* Sema, clang::Expr* E, llvm::StringRef Err) {
+    DiagnosticsEngine& Diags = Sema->getDiagnostics();
+    Diags.Report(E->getLocStart(),
+                 Diags.getCustomDiagID(
+                     clang::DiagnosticsEngine::Level::Error,
+                     "ValueExtractionSynthesizer could not find: '%0'."))
+        << Err;
     return false;
   }
 
-  bool ValueExtractionSynthesizer::FindAndCacheRuntimeDecls() {
+  bool ValueExtractionSynthesizer::FindAndCacheRuntimeDecls(clang::Expr* E) {
     assert(!m_gClingVD && "Called multiple times!?");
     DeclContext* NSD = m_Context->getTranslationUnitDecl();
     clang::VarDecl* clingVD = nullptr;
     if (m_Sema->getLangOpts().CPlusPlus) {
       if (!(NSD = utils::Lookup::Namespace(m_Sema, "cling")))
-        return VSError("cling namespace not defined");
+        return VSError(m_Sema, E, "cling namespace");
       if (!(NSD = utils::Lookup::Namespace(m_Sema, "runtime", NSD)))
-        return VSError("cling::runtime namespace not defined");
-      if (!(clingVD = cast<VarDecl>(utils::Lookup::Named(m_Sema, "gCling",
-                                                            NSD))))
-        return VSError("cling::runtime::gCling not defined");
-      if (!NSD)
-        return VSError("cling::runtime namespace not defined");
-
+        return VSError(m_Sema, E, "cling::runtime namespace");
+      if (!(clingVD = dyn_cast_or_null<VarDecl>(
+                utils::Lookup::Named(m_Sema, "gCling", NSD))))
+        return VSError(m_Sema, E, "cling::runtime::gCling");
       if (!(NSD = utils::Lookup::Namespace(m_Sema, "internal", NSD)))
-        return VSError("cling::runtime::internal namespace not defined");
+        return VSError(m_Sema, E, "cling::runtime::internal namespace");
     }
     LookupResult R(*m_Sema, &m_Context->Idents.get("setValueNoAlloc"),
                    SourceLocation(), Sema::LookupOrdinaryName,
@@ -436,25 +437,23 @@ namespace {
 
     m_Sema->LookupQualifiedName(R, NSD);
     if (R.empty())
-      return VSError("Cannot find cling::runtime::internal::setValueNoAlloc");
+      return VSError(m_Sema, E, "cling::runtime::internal::setValueNoAlloc");
 
     const bool ADL = false;
     CXXScopeSpec CSS;
     m_UnresolvedNoAlloc = m_Sema->BuildDeclarationNameExpr(CSS, R, ADL).get();
     if (!m_UnresolvedNoAlloc)
-      return VSError("Could not build cling::runtime::internal"
-                     "::setValueNoAlloc");
+      return VSError(m_Sema, E, "cling::runtime::internal::setValueNoAlloc");
 
     R.clear();
     R.setLookupName(&m_Context->Idents.get("setValueWithAlloc"));
     m_Sema->LookupQualifiedName(R, NSD);
     if (R.empty())
-      return VSError("Cannot find cling::runtime::internal::setValueWithAlloc");
+      return VSError(m_Sema, E, "cling::runtime::internal::setValueWithAlloc");
 
     m_UnresolvedWithAlloc = m_Sema->BuildDeclarationNameExpr(CSS, R, ADL).get();
     if (!m_UnresolvedWithAlloc)
-      return VSError("Could not build cling::runtime::internal"
-                     "::setValueWithAlloc");
+      return VSError(m_Sema, E, "cling::runtime::internal::setValueWithAlloc");
 
     R.clear();
     R.setLookupName(&m_Context->Idents.get("copyArray"));
@@ -466,11 +465,11 @@ namespace {
     // Once the import of template functions becomes supported by clang,
     // this check can be de-activated.
     if (!m_isChildInterpreter && R.empty())
-      return VSError("Cannot find cling::runtime::internal::copyArray");
+      return VSError(m_Sema, E, "cling::runtime::internal::copyArray");
 
     m_UnresolvedCopyArray = m_Sema->BuildDeclarationNameExpr(CSS, R, ADL).get();
     if (!m_UnresolvedCopyArray)
-      return VSError("Could not build cling::runtime::internal::copyArray");
+      return VSError(m_Sema, E, "cling::runtime::internal::copyArray");
 
     m_gClingVD = clingVD;
     return true;

--- a/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -167,13 +167,18 @@ namespace cling {
         Expr* SVRInit = SynthesizeSVRInit(lastExpr);
         // if we had return stmt update to execute the SVR init, even if the
         // wrapper returns void.
-        if (RS) {
-          if (ImplicitCastExpr* VoidCast
-              = dyn_cast<ImplicitCastExpr>(RS->getRetValue()))
-            VoidCast->setSubExpr(SVRInit);
+        if (SVRInit) {
+          if (RS) {
+            if (ImplicitCastExpr* VoidCast
+                = dyn_cast<ImplicitCastExpr>(RS->getRetValue()))
+              VoidCast->setSubExpr(SVRInit);
+          } else
+            **I = SVRInit;
+        } else {
+          // FIXME: Do this atomically or something so that AST context will not
+          // contain Expr(s) that are unused for the rest of it's life.
+          return Result(D, false);
         }
-        else if (SVRInit)
-          **I = SVRInit;
       }
     }
     return Result(D, true);
@@ -313,6 +318,8 @@ namespace {
         TypeSourceInfo* ETSI
           = m_Context->getTrivialTypeSourceInfo(ETy, noLoc);
 
+        assert(!Call.isInvalid() && "Invalid Call before building new");
+
         Call = m_Sema->BuildCXXNew(E->getSourceRange(),
                                    /*useGlobal ::*/true,
                                    /*placementLParen*/ noLoc,
@@ -325,6 +332,12 @@ namespace {
                                    /*directInitRange*/E->getSourceRange(),
                                    /*initializer*/E
                                    );
+        if (Call.isInvalid()) {
+          m_Sema->Diag(E->getLocStart(), diag::err_undeclared_var_use)
+            << "operator new";
+          return Call.get();
+        }
+
         // Handle possible cleanups:
         Call = m_Sema->ActOnFinishFullExpr(Call.get());
       }
@@ -382,11 +395,10 @@ namespace {
       }
     }
 
-
     assert(!Call.isInvalid() && "Invalid Call");
 
     // Extend the scope of the temporary cleaner if applicable.
-    if (Cleanups) {
+    if (Cleanups && !Call.isInvalid()) {
       Cleanups->setSubExpr(Call.get());
       Cleanups->setValueKind(Call.get()->getValueKind());
       Cleanups->setType(Call.get()->getType());

--- a/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -12,8 +12,8 @@
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/Value.h"
-
 #include "cling/Utils/AST.h"
+#include "cling/Utils/Output.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclGroup.h"
@@ -204,8 +204,8 @@ namespace {
 }
 
   Expr* ValueExtractionSynthesizer::SynthesizeSVRInit(Expr* E) {
-    if (!m_gClingVD)
-      FindAndCacheRuntimeDecls();
+    if (!m_gClingVD && !FindAndCacheRuntimeDecls())
+      return nullptr;
 
     // Build a reference to gCling
     ExprResult gClingDRE
@@ -407,34 +407,54 @@ namespace {
     return Call.get();
   }
 
-  void ValueExtractionSynthesizer::FindAndCacheRuntimeDecls() {
+  static bool VSError(const char* err) {
+    cling::errs() << "ValueExtractionSynthesizer error: " << err << ".\n";
+    return false;
+  }
+
+  bool ValueExtractionSynthesizer::FindAndCacheRuntimeDecls() {
     assert(!m_gClingVD && "Called multiple times!?");
     DeclContext* NSD = m_Context->getTranslationUnitDecl();
+    clang::VarDecl* clingVD = nullptr;
     if (m_Sema->getLangOpts().CPlusPlus) {
-      NSD = utils::Lookup::Namespace(m_Sema, "cling");
-      NSD = utils::Lookup::Namespace(m_Sema, "runtime", NSD);
-      m_gClingVD = cast<VarDecl>(utils::Lookup::Named(m_Sema, "gCling", NSD));
-      NSD = utils::Lookup::Namespace(m_Sema, "internal",NSD);
+      if (!(NSD = utils::Lookup::Namespace(m_Sema, "cling")))
+        return VSError("cling namespace not defined");
+      if (!(NSD = utils::Lookup::Namespace(m_Sema, "runtime", NSD)))
+        return VSError("cling::runtime namespace not defined");
+      if (!(clingVD = cast<VarDecl>(utils::Lookup::Named(m_Sema, "gCling",
+                                                            NSD))))
+        return VSError("cling::runtime::gCling not defined");
+      if (!NSD)
+        return VSError("cling::runtime namespace not defined");
+
+      if (!(NSD = utils::Lookup::Namespace(m_Sema, "internal", NSD)))
+        return VSError("cling::runtime::internal namespace not defined");
     }
     LookupResult R(*m_Sema, &m_Context->Idents.get("setValueNoAlloc"),
                    SourceLocation(), Sema::LookupOrdinaryName,
                    Sema::ForRedeclaration);
 
     m_Sema->LookupQualifiedName(R, NSD);
-    assert(!R.empty()
-           && "Cannot find cling::runtime::internal::setValueNoAlloc");
+    if (R.empty())
+      return VSError("Cannot find cling::runtime::internal::setValueNoAlloc");
 
+    const bool ADL = false;
     CXXScopeSpec CSS;
-    m_UnresolvedNoAlloc
-      = m_Sema->BuildDeclarationNameExpr(CSS, R, /*ADL*/ false).get();
+    m_UnresolvedNoAlloc = m_Sema->BuildDeclarationNameExpr(CSS, R, ADL).get();
+    if (!m_UnresolvedNoAlloc)
+      return VSError("Could not build cling::runtime::internal"
+                     "::setValueNoAlloc");
 
     R.clear();
     R.setLookupName(&m_Context->Idents.get("setValueWithAlloc"));
     m_Sema->LookupQualifiedName(R, NSD);
-    assert(!R.empty()
-           && "Cannot find cling::runtime::internal::setValueWithAlloc");
-    m_UnresolvedWithAlloc
-      = m_Sema->BuildDeclarationNameExpr(CSS, R, /*ADL*/ false).get();
+    if (R.empty())
+      return VSError("Cannot find cling::runtime::internal::setValueWithAlloc");
+
+    m_UnresolvedWithAlloc = m_Sema->BuildDeclarationNameExpr(CSS, R, ADL).get();
+    if (!m_UnresolvedWithAlloc)
+      return VSError("Could not build cling::runtime::internal"
+                     "::setValueWithAlloc");
 
     R.clear();
     R.setLookupName(&m_Context->Idents.get("copyArray"));
@@ -445,10 +465,15 @@ namespace {
     // parent interpreter, but it will fail, because this is a template function.
     // Once the import of template functions becomes supported by clang,
     // this check can be de-activated.
-    if (!m_isChildInterpreter)
-      assert(!R.empty() && "Cannot find cling::runtime::internal::copyArray");
-    m_UnresolvedCopyArray
-      = m_Sema->BuildDeclarationNameExpr(CSS, R, /*ADL*/ false).get();
+    if (!m_isChildInterpreter && R.empty())
+      return VSError("Cannot find cling::runtime::internal::copyArray");
+
+    m_UnresolvedCopyArray = m_Sema->BuildDeclarationNameExpr(CSS, R, ADL).get();
+    if (!m_UnresolvedCopyArray)
+      return VSError("Could not build cling::runtime::internal::copyArray");
+
+    m_gClingVD = clingVD;
+    return true;
   }
 } // end namespace cling
 

--- a/lib/Interpreter/ValueExtractionSynthesizer.h
+++ b/lib/Interpreter/ValueExtractionSynthesizer.h
@@ -90,7 +90,7 @@ public:
 
     // Find and cache cling::runtime::gCling, setValueNoAlloc,
     // setValueWithAlloc on first request.
-    bool FindAndCacheRuntimeDecls();
+    bool FindAndCacheRuntimeDecls(clang::Expr*);
   };
 
 } // namespace cling

--- a/lib/Interpreter/ValueExtractionSynthesizer.h
+++ b/lib/Interpreter/ValueExtractionSynthesizer.h
@@ -90,7 +90,7 @@ public:
 
     // Find and cache cling::runtime::gCling, setValueNoAlloc,
     // setValueWithAlloc on first request.
-    void FindAndCacheRuntimeDecls();
+    bool FindAndCacheRuntimeDecls();
   };
 
 } // namespace cling

--- a/test/Driver/C.c
+++ b/test/Driver/C.c
@@ -16,5 +16,8 @@
 int printf(const char*,...);
 printf("CHECK 123 %p\n", gCling); // CHECK: CHECK 123
 
-// expected-no-diagnostics
+12 // expected-error {{ValueExtractionSynthesizer could not find: 'cling::runtime::internal::setValueNoAlloc'.}}
+
+32 // expected-error {{ValueExtractionSynthesizer could not find: 'cling::runtime::internal::setValueNoAlloc'.}}
+
 .q

--- a/test/ErrorRecovery/ABI.C
+++ b/test/ErrorRecovery/ABI.C
@@ -7,11 +7,43 @@
 //------------------------------------------------------------------------------
 
 // RUN: %cling -C -E -P  %s | %cling -nostdinc++ -Xclang -verify 2>&1 | FileCheck %s
-// RUN: %cling -C -E -P -DCLING_NO_BUILTIN %s | %cling -nostdinc++ -nobuiltininc -Xclang -verify 2>&1 | FileCheck %s
+// RUN: %cling -C -E -P -DCLING_VALEXTRACT_ERR %s | %cling -nostdinc++ -nobuiltininc -Xclang -verify 2>&1 | FileCheck %s
+// RUN: %cling -C -E -P -DCLING_VALEXTRACT_ERR2 %s | %cling -nostdinc++ -nobuiltininc -Xclang -verify 2>&1 | FileCheck %s
+// RUN: %cling -C -E -P -DCLING_VALEXTRACT_ERR3 %s | %cling -nostdinc++ -nobuiltininc -Xclang -verify 2>&1 | FileCheck %s
+// RUN: %cling -C -E -P -DCLING_VALEXTRACT_ERR4 %s | %cling -nostdinc++ -nobuiltininc -Xclang -verify 2>&1 | FileCheck %s
 
 // expected-error@input_line_1:1 {{'new' file not found}}
 
 //      CHECK: Warning in cling::IncrementalParser::CheckABICompatibility():
 // CHECK-NEXT:  Possible C++ standard library mismatch, compiled with {{.*$}}
+
+
+#if defined(CLING_VALEXTRACT_ERR) || defined(CLING_VALEXTRACT_ERR2) || \
+    defined(CLING_VALEXTRACT_ERR3) || defined(CLING_VALEXTRACT_ERR4)
+
+struct Trigger {} Tr;
+
+#ifdef CLING_VALEXTRACT_ERR
+Tr // expected-error@2 {{ValueExtractionSynthesizer could not find: 'cling namespace'.}}
+#endif
+
+#ifdef CLING_VALEXTRACT_ERR2
+namespace cling {}
+Tr // expected-error@2 {{ValueExtractionSynthesizer could not find: 'cling::runtime namespace'.}}
+#endif
+
+#ifdef CLING_VALEXTRACT_ERR3
+namespace cling { namespace runtime {} }
+Tr // expected-error@2 {{ValueExtractionSynthesizer could not find: 'cling::runtime::gCling'.}}
+#endif
+
+#ifdef CLING_VALEXTRACT_ERR4
+namespace cling { namespace runtime { void* gCling; namespace internal { void* setValueWithAlloc; void* setValueNoAlloc; } } }
+Tr // expected-error@2 {{ValueExtractionSynthesizer could not find: 'cling::runtime::internal::copyArray'.}}
+// Make sure not to crash on subsequent attempts
+Tr // expected-error@2 {{ValueExtractionSynthesizer could not find: 'cling::runtime::internal::copyArray'.}}
+#endif
+
+#endif
 
 .q


### PR DESCRIPTION
ValueExtractionSynthesizer is currently doing -error checking- via asserts which is meaningless in Release and will just let a crash happen. These changes make it more defensive and report error's in a nicer way.