### PR TITLE
Fix crash in TextInput and remove unused method.

### DIFF
--- a/lib/UserInterface/textinput/History.h
+++ b/lib/UserInterface/textinput/History.h
@@ -44,8 +44,6 @@ namespace textinput {
     }
     size_t GetSize() const { return fEntries.size(); }
 
-    size_t MatchIndex(size_t StartIdx, const char* regexp, size_t again = 0);
-
     void AddLine(const std::string& line);
     void ModifyLine(size_t Idx, const char* line) {
       fEntries[fEntries.size() - 1 - Idx] = line;


### PR DESCRIPTION
Starting running into this. The basic problem (in cling's usage) can be seen in UserInterface.cpp

```
    std::unique_ptr<StreamReader> R(StreamReader::Create());
    std::unique_ptr<TerminalDisplay> D(TerminalDisplay::Create());
    TextInput TI(*R, *D, histfilePath.empty() ? 0 : histfilePath.c_str());

```
It's very clear **TI** references both **R** & **D** which will both be destroyed after **TI**, what is less clear is both **R** & **D** will wind up holding an invalid pointer from **TI** through **fContext**.