### PR TITLE
Fix crash when dumping an un-evaluated cling::Value

### DIFF
--- a/include/cling/Interpreter/RuntimePrintValue.h
+++ b/include/cling/Interpreter/RuntimePrintValue.h
@@ -21,14 +21,20 @@
 namespace cling {
 
   class Value;
+  namespace valuePrinterInternal {
+    extern const char* const kEmptyCollection;
+    extern const char* const kUndefined;
+  }
 
   // General fallback - prints the address
   std::string printValue(const void *ptr);
 
   // Fallback for e.g. vector<bool>'s bit iterator:
   template <class T,
-    class = typename std::enable_if<!std::is_pointer<T>::value>::type>
-  std::string printValue(const T& val) { return "{not representable}"; }
+            class = typename std::enable_if<!std::is_pointer<T>::value>::type>
+  std::string printValue(const T& val) {
+    return valuePrinterInternal::kUndefined;
+  }
 
   // void pointer
   std::string printValue(const void **ptr);
@@ -113,10 +119,6 @@ namespace cling {
 
   // cling::Value
   std::string printValue(const Value *value);
-
-  namespace valuePrinterInternal {
-    extern const char* const kEmptyCollection;
-  }
 
   // Collections internal
   namespace collectionPrinterInternal {

--- a/lib/Interpreter/Value.cpp
+++ b/lib/Interpreter/Value.cpp
@@ -231,9 +231,15 @@ namespace cling {
   namespace valuePrinterInternal {
     std::string printTypeInternal(const Value& V);
     std::string printValueInternal(const Value& V);
+    extern const char* const kInvalid;
   } // end namespace valuePrinterInternal
 
   void Value::print(llvm::raw_ostream& Out, bool Escape) const {
+    if (!m_Interpreter) {
+      Out << valuePrinterInternal::kInvalid << "\n";
+      return;
+    }
+
     // Save the default type string representation so output can occur as one
     // operation (calling printValueInternal below may write to stderr).
     const std::string Type = valuePrinterInternal::printTypeInternal(*this);

--- a/lib/Interpreter/ValuePrinter.cpp
+++ b/lib/Interpreter/ValuePrinter.cpp
@@ -55,6 +55,8 @@ extern "C" void cling_PrintValue(void * /*cling::Value**/ V) {
 namespace cling {
   namespace valuePrinterInternal {
     extern const char* const kEmptyCollection = "{}";
+    extern const char* const kUndefined = "<<<undefined>>>";
+    extern const char* const kInvalid = "<<<invalid>>>";
   }
 }
 
@@ -602,7 +604,7 @@ static std::string callPrintValue(const Value& V, const void* Val) {
                              "Could not execute cling::printValue with '%0'");
   Diag.Report(Interp->getSourceLocation(), ID) << getTypeString(V);
 
-  return "ERROR in cling's callPrintValue(): missing value string.";
+  return valuePrinterInternal::kUndefined;
 }
 
 template <typename T>
@@ -847,7 +849,7 @@ namespace cling {
       }
       strm << "]";
     } else
-      strm << "<<<invalid>>> " << printAddress(value, '@');
+      strm << valuePrinterInternal::kInvalid << ' ' << printAddress(value, '@');
 
     return strm.str();
   }
@@ -855,10 +857,12 @@ namespace cling {
   namespace valuePrinterInternal {
 
     std::string printTypeInternal(const Value &V) {
+      assert(V.getInterpreter() && "Invalid cling::Value");
       return printQualType(V.getASTContext(), V.getType());
     }
 
     std::string printValueInternal(const Value &V) {
+      assert(V.getInterpreter() && "Invalid cling::Value");
       static bool includedRuntimePrintValue = false; // initialized only once as a static function variable
       // Include "RuntimePrintValue.h" only on the first printing.
       // This keeps the interpreter lightweight and reduces the startup time.

--- a/test/Interfaces/evaluate.C
+++ b/test/Interfaces/evaluate.C
@@ -15,8 +15,10 @@
 cling::Value V;
 V // CHECK: (cling::Value &) <<<invalid>>> @0x{{.*}}
 
+V.dump(); // CHECK-NEXT: <<<invalid>>>
+
 gCling->evaluate("return 1;", V);
-V // CHECK: (cling::Value &) boxes [(int) 1]
+V // CHECK-NEXT: (cling::Value &) boxes [(int) 1]
 
 gCling->evaluate("(void)V", V);
 V // CHECK-NEXT: (cling::Value &) boxes [(void) ]

--- a/test/Prompt/ValuePrinter/Regression.C
+++ b/test/Prompt/ValuePrinter/Regression.C
@@ -90,6 +90,7 @@ auto bla=[](double *x, double *par, int blub){return x[0]*blub;} // CHECK: ((lam
 #include <functional>
 using namespace std::placeholders;
 auto fn_moo = std::bind (bla, _1,_2,10) // CHECK: ERROR in cling's callPrintValue(): missing value string.
+// expected-error {{Could not execute cling::printValue with '{{.*}}'}}
 // expected-error {{use of undeclared identifier 'lambda'}}
 // expected-error {{expected expression}}
 // expected-error {{type name requires a specifier or qualifier}}

--- a/test/Prompt/ValuePrinter/Regression.C
+++ b/test/Prompt/ValuePrinter/Regression.C
@@ -89,7 +89,7 @@ auto bla=[](double *x, double *par, int blub){return x[0]*blub;} // CHECK: ((lam
 
 #include <functional>
 using namespace std::placeholders;
-auto fn_moo = std::bind (bla, _1,_2,10) // CHECK: ERROR in cling's callPrintValue(): missing value string.
+auto fn_moo = std::bind (bla, _1,_2,10) // CHECK: <<<undefined>>>
 // expected-error {{Could not execute cling::printValue with '{{.*}}'}}
 // expected-error {{use of undeclared identifier 'lambda'}}
 // expected-error {{expected expression}}


### PR DESCRIPTION
This fixes the following code which will currently crash:
```
cling::Value V;
V.dump();
```

The first commit while not totally related was for conflict resolution against 27aea4b and reports the error through clang's diagnostics.