### PR TITLE
Fix Windows exception handling for newer LLVM interfaces.

### DIFF
--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -461,7 +461,7 @@ namespace cling {
       // __dso_handle is inserted for the link phase, as macro is useless then
       m_Executor->addSymbol("__dso_handle", this, true);
 
-#ifdef LLVM_ON_WIN32
+#ifdef CLING_WIN_SEH_EXCEPTIONS
       // Windows C++ SEH handler
       m_Executor->addSymbol("_CxxThrowException",
           utils::FunctionToVoidPtr(&platform::ClingRaiseSEHException), true);


### PR DESCRIPTION
Block it’s usage around CLING_WIN_SEH_EXCEPTIONS macro.