### PR TITLE
Explicitly tell clang what std version to use.

### DIFF
--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -745,13 +745,13 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // Would be nice on Linux but will warn 'argument unused during compilation'
     // when -nostdinc++ is passed
 #ifdef __APPLE__
-      if (!COpts.StdLib) {
+    if (!COpts.StdLib) {
   #ifdef _LIBCPP_VERSION
-        argvCompile.push_back("-stdlib=libc++");
+      argvCompile.push_back("-stdlib=libc++");
   #elif defined(__GLIBCXX__)
-        argvCompile.push_back("-stdlib=libstdc++");
+      argvCompile.push_back("-stdlib=libstdc++");
   #endif
-      }
+    }
 #endif
 
     if (!COpts.HasOutput || !HasInput) {

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -624,16 +624,16 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
   static bool
   SetupCompiler(CompilerInstance* CI, const CompilerOptions& CompilerOpts,
                 bool Lang = true, bool Targ = true) {
+    LangOptions& LangOpts = CI->getLangOpts();
     // Set the language options, which cling needs.
     // This may have already been done via a precompiled header
     if (Lang)
-      SetClingCustomLangOpts(CI->getLangOpts(), CompilerOpts);
+      SetClingCustomLangOpts(LangOpts, CompilerOpts);
 
     PreprocessorOptions& PPOpts = CI->getInvocation().getPreprocessorOpts();
     SetPreprocessorFromBinary(PPOpts);
 
     // Sanity check that clang delivered the language standard requested
-    const auto& LangOpts = CI->getLangOpts();
     if (CompilerOpts.DefaultLanguage(LangOpts)) {
       switch (CxxStdCompiledWith()) {
         case 17: assert(LangOpts.CPlusPlus1z && "Language version mismatch");
@@ -644,9 +644,9 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     }
 
     PPOpts.addMacroDef("__CLING__");
-    if (CI->getLangOpts().CPlusPlus11 == 1)
+    if (LangOpts.CPlusPlus11 == 1)
       PPOpts.addMacroDef("__CLING__CXX11");
-    if (CI->getLangOpts().CPlusPlus14 == 1)
+    if (LangOpts.CPlusPlus14 == 1)
       PPOpts.addMacroDef("__CLING__CXX14");
 
     if (CI->getDiagnostics().hasErrorOccurred()) {
@@ -661,11 +661,11 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       return false;
     }
 
-    CI->getTarget().adjust(CI->getLangOpts());
+    CI->getTarget().adjust(LangOpts);
 
     // This may have already been done via a precompiled header
     if (Targ)
-      SetClingTargetLangOpts(CI->getLangOpts(), CI->getTarget(), CompilerOpts);
+      SetClingTargetLangOpts(LangOpts, CI->getTarget(), CompilerOpts);
 
     SetPreprocessorFromTarget(PPOpts, CI->getTarget().getTriple());
     return true;

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -418,7 +418,7 @@ namespace {
 #endif
 
     if (CompilerOpts.DefaultLanguage(Opts)) {
-#ifdef __STRICT_ANSI__
+#ifdef __STRICT_ANSI__ || defined(LLVM_ON_WIN32)
       Opts.GNUMode = 0;
 #else
       Opts.GNUMode = 1;


### PR DESCRIPTION
Clang is deducing the language standard on it's own, then uses this value durring initialization, and cling then attempts to change it afterward.

Avoid this by telling clang what is desired early on.
And don't have Windows use GNU keywords by default.