### PR TITLE
Fix tests on platforms with __float128 without forcing C++14.

### DIFF
--- a/test/CodeUnloading/AtExit.C
+++ b/test/CodeUnloading/AtExit.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling -std=c++14 -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
 // FIXME: cat %s | %cling -fsyntax-only -Xclang -verify 2>&1
 
 // Test to check functions registered via atexit are intercepted, and __dso_handle
@@ -46,7 +46,7 @@ cling::Interpreter * gChild = 0;
   ChildInterp.execute("atexit(atexit_c);");
 }
 // ChildInterp
-// CHECK-NEXT: atexit_c 1
+// CHECK: atexit_c 1
 
 static void atexit_f() {
   printf("atexit_f %s\n", gCling==__dso_handle ? "true" : "false");

--- a/test/Interfaces/echo.C
+++ b/test/Interfaces/echo.C
@@ -6,15 +6,15 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling -std=c++14 2>&1 | FileCheck %s
+// RUN: cat %s | %cling 2>&1 | FileCheck %s
 
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Value.h"
 
 gCling->echo("1;");
-// CHECK: 1
+// CHECK: (int) 1
 cling::Value V;
 gCling->echo("2;", &V);
 V
-// CHECK-NEXT: 2
+// CHECK-NEXT: (int) 2
 // CHECK-NEXT: (cling::Value &) boxes [(int) 2]


### PR DESCRIPTION
This reverts commit c11224dce022f05a4e2bf7914a4b878c54f6bbca.