### PR TITLE
Call CompilerOptions:: DefaultLanguage before setting -std=

### DIFF
--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -46,7 +46,7 @@ namespace cling {
     /// or './cling -x c') that this shouldn't be done.  This will return false
     /// in those cases.
     ///
-    bool DefaultLanguage(const clang::LangOptions&) const;
+    bool DefaultLanguage(const clang::LangOptions* = nullptr) const;
 
     unsigned Language : 1;
     unsigned ResourceDir : 1;

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -405,7 +405,7 @@ namespace {
     Opts.FastMath = 1;
 #endif
 
-    if (CompilerOpts.DefaultLanguage(Opts)) {
+    if (CompilerOpts.DefaultLanguage(&Opts)) {
 #ifdef __STRICT_ANSI__
       Opts.GNUMode = 0;
 #else
@@ -429,7 +429,7 @@ namespace {
       Opts.MicrosoftExt = 0;
     }
 
-    if (CompilerOpts.DefaultLanguage(Opts)) {
+    if (CompilerOpts.DefaultLanguage(&Opts)) {
 #if _GLIBCXX_USE_FLOAT128
       // We are compiling with libstdc++ with __float128 enabled.
       if (!Target.hasFloat128Type()) {
@@ -634,7 +634,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     SetPreprocessorFromBinary(PPOpts);
 
     // Sanity check that clang delivered the language standard requested
-    if (CompilerOpts.DefaultLanguage(LangOpts)) {
+    if (CompilerOpts.DefaultLanguage(&LangOpts)) {
       switch (CxxStdCompiledWith()) {
         case 17: assert(LangOpts.CPlusPlus1z && "Language version mismatch");
         case 14: assert(LangOpts.CPlusPlus14 && "Language version mismatch");
@@ -732,18 +732,17 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       // We do C++ by default; append right after argv[0] if no "-x" given
       argvCompile.push_back("-x");
       argvCompile.push_back( "c++");
-
-      if (!COpts.StdVersion) {
-        // By default, set the standard to what cling was compiled with.
-        // clang::driver::Compilation will do various things while initializing
-        // and by enforcing the std version now cling is telling clang what to
-        // do, rather than after clang has dedcuded a default.
-        switch (CxxStdCompiledWith()) {
-          case 17: argvCompile.emplace_back("-std=c++1z"); break;
-          case 14: argvCompile.emplace_back("-std=c++14"); break;
-          case 11: argvCompile.emplace_back("-std=c++11"); break;
-          default: llvm_unreachable("Unrecognized C++ version");
-        }
+    }
+    if (COpts.DefaultLanguage()) {
+      // By default, set the standard to what cling was compiled with.
+      // clang::driver::Compilation will do various things while initializing
+      // and by enforcing the std version now cling is telling clang what to
+      // do, rather than after clang has dedcuded a default.
+      switch (CxxStdCompiledWith()) {
+        case 17: argvCompile.emplace_back("-std=c++1z"); break;
+        case 14: argvCompile.emplace_back("-std=c++14"); break;
+        case 11: argvCompile.emplace_back("-std=c++11"); break;
+        default: llvm_unreachable("Unrecognized C++ version");
       }
     }
     // argv[0] already inserted, get the rest

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -145,7 +145,7 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
   }
 }
 
-bool CompilerOptions::DefaultLanguage(const LangOptions& LangOpts) const {
+bool CompilerOptions::DefaultLanguage(const LangOptions* LangOpts) const {
   // When StdVersion is set (-std=c++11, -std=gnu++11, etc.) then definitely
   // don't setup the defaults, as they may interfere with what the user is doing
   if (StdVersion)
@@ -154,7 +154,7 @@ bool CompilerOptions::DefaultLanguage(const LangOptions& LangOpts) const {
   // Also don't set up the defaults when language is explicitly set; unless
   // the language was set to generate a PCH, in which case definitely do.
   if (Language)
-    return LangOpts.CompilingPCH || HasOutput;
+    return HasOutput || (LangOpts && LangOpts->CompilingPCH);
 
   return true;
 }


### PR DESCRIPTION
Should fix issue over eagerly setting -std= when compiling a precompiled header.