### PR TITLE
Fix broken import of class types.

### DIFF
--- a/lib/Interpreter/ExternalInterpreterSource.h
+++ b/lib/Interpreter/ExternalInterpreterSource.h
@@ -71,16 +71,16 @@ namespace cling {
         bool Import(clang::DeclContext::lookup_result lookupResult,
                     const clang::DeclContext *childCurrentDeclContext,
                     clang::DeclarationName &childDeclName,
-                    clang::DeclarationName &parentDeclName);
+                    const clang::DeclarationName &parentDeclName);
 
         void ImportDeclContext(clang::DeclContext *declContextToImport,
                                clang::DeclarationName &childDeclName,
-                               clang::DeclarationName &parentDeclName,
+                               const clang::DeclarationName &parentDeclName,
                                const clang::DeclContext *childCurrentDeclContext);
 
         void ImportDecl(clang::Decl *declToImport,
                         clang::DeclarationName &childDeclName,
-                        clang::DeclarationName &parentDeclName,
+                        const clang::DeclarationName &parentDeclName,
                         const clang::DeclContext *childCurrentDeclContext);
 
         void addToImportedDecls(clang::DeclarationName child,

--- a/test/MultipleInterpreters/MultipleInterpreters.C
+++ b/test/MultipleInterpreters/MultipleInterpreters.C
@@ -6,18 +6,17 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
 
 // Test to check the functionality of the multiple interpreters.
 // Create a "child" interpreter and use gCling as its "parent".
 
 #include "cling/Interpreter/Interpreter.h"
-#include "cling/MetaProcessor/MetaProcessor.h"
-// #include "cling/Utils/Output.h"
-
 
 //Declare something in the parent interpreter
 int foo(){ return 42; }
+struct InParent {};
+InParent IP;
 
 // OR
 //gCling->declare("void foo(){ cling::outs() << \"foo(void)\\n\"; }");
@@ -31,7 +30,17 @@ const char* argV[1] = {"cling"};
 {
   cling::Interpreter ChildInterp(*gCling, 1, argV);
   ChildInterp.declare("void foo(int i){ printf(\"foo(int) = %d\\n\", i); }\n");
-  ChildInterp.echo("foo()"); //CHECK: (int) 42
-  ChildInterp.echo("foo(1)"); //CHECK: foo(int) = 1
+
+  ChildInterp.echo("foo()");
+  //      CHECK: (int) 42
+
+  ChildInterp.echo("foo(1)");
+  // CHECK-NEXT: foo(int) = 1
+
+  ChildInterp.echo("InParent FC");
+  // CHECK-NEXT: (InParent &) @0x{{.*}}
 }
+
+// expected-no-diagnostics
+
 .q

--- a/test/MultipleInterpreters/MultipleInterpreters.C
+++ b/test/MultipleInterpreters/MultipleInterpreters.C
@@ -15,7 +15,7 @@
 
 //Declare something in the parent interpreter
 int foo(){ return 42; }
-struct InParent {};
+struct InParent { operator int() const { return 84; } };
 InParent IP;
 
 // OR
@@ -39,6 +39,16 @@ const char* argV[1] = {"cling"};
 
   ChildInterp.echo("InParent FC");
   // CHECK-NEXT: (InParent &) @0x{{.*}}
+
+  ChildInterp.echo("static_cast<int>(IP)");
+  // CHECK-NEXT: (int) 84
+}
+
+{
+  cling::Interpreter ChildInterp(*gCling, 1, argV);
+
+  ChildInterp.echo("static_cast<int>(IP)");
+  // CHECK: (int) 84
 }
 
 // expected-no-diagnostics


### PR DESCRIPTION
There are two issues, the first seems like cling's fault, the second possibly clangs.

1. Importing a CxxConstructor decl can fail as cling it is using the string name for lookup.
2. Importing C++ conversion operators does not work.