### PR TITLE
Windows: Fix declaration for C99 and re-enable Gnu.C test.

### DIFF
--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -433,9 +433,12 @@ namespace cling {
 #else
     const char* Spec = "__clrcall";
 #endif
+    const bool ParamNames = LangOpts.C99;
     Strm << Linkage << " " << Spec << " int (*__dllonexit("
-         << "int (" << Spec << " *f)(void**, void**), void**, void**))"
-         "(void**, void**)";
+         << "int (" << Spec << " *f)(void**, void**),"
+         << "void**" << (ParamNames ? " a" : "") << ","
+         << "void**" << (ParamNames ? " b" : "")
+         << "))(void**, void**)";
       if (EmitDefinitions)
         Strm << " { __cxa_atexit((void(*)(void*))f, 0, __dso_handle);"
                 " return f; }\n";

--- a/test/Driver/Gnu.C
+++ b/test/Driver/Gnu.C
@@ -7,9 +7,11 @@
 //------------------------------------------------------------------------------
 
 // RUN: cat %s | %cling -std=gnu99 -x c -Xclang -verify 2>&1 | FileCheck %s
-// RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++11 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++14 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++1z -Xclang -verify 2>&1 | FileCheck %s
+
+// RUN: cat %s | %cling --noruntime -D__STRICT_ANSI__ -std=gnu++11 -Xclang -verify 2>&1 | FileCheck %s
+// --noruntime is for Windows which cannot include VSudio C++ headers in C++11
 
 #ifdef __cplusplus
 extern "C" int printf(const char*, ...);

--- a/test/Driver/Gnu.C
+++ b/test/Driver/Gnu.C
@@ -10,7 +10,6 @@
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++11 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++14 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++1z -Xclang -verify 2>&1 | FileCheck %s
-// REQUIRES: not_system-windows
 
 #ifdef __cplusplus
 extern "C" int printf(const char*, ...);


### PR DESCRIPTION
The test was failing for a reason that likely shouldn't be ignored.

This reverts commit 5947e13cb99052b6f7a5b501244ee2be9be9d080.
