### PR TITLE
Fix recursive registration of __cxa_atexit & atexit functions.

### DIFF
--- a/include/cling/Utils/OrderedMap.h
+++ b/include/cling/Utils/OrderedMap.h
@@ -1,0 +1,116 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author: Roman Zulak
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef CLING_ORDERED_MAP_H
+#define CLING_ORDERED_MAP_H
+
+#include <unordered_map>
+#include <cassert>
+
+namespace cling {
+namespace utils {
+
+///\brief Thin wrapper class for tracking the order of insertion into a
+/// std::unordered_map.
+///
+/// Only supports 'emplace' and '[Key]' for insertion of values, and adds an
+/// additional parameter to 'erase' so that a mapped value can be moved into
+/// local storage before erasing the iterator occurs.
+///
+template <typename Key, typename Value>
+class OrderedMap {
+  typedef std::unordered_map<Key, Value> map_t;
+  // Would this be faster as a std::unoredered_map<Key, size_t> for erasure?
+  typedef std::vector<typename map_t::const_iterator> order_t;
+
+  map_t m_Map;
+  order_t m_Order;
+
+public:
+  typedef typename map_t::iterator iterator;
+  typedef typename map_t::const_iterator const_iterator;
+  typedef typename map_t::mapped_type mapped_type;
+
+  template <typename... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    auto Rval = m_Map.emplace(std::forward<Args>(args)...);
+    if (Rval.second) m_Order.emplace_back(Rval.first);
+    return Rval;
+  }
+
+  Value& operator[](const Key& K) {
+    iterator Itr = find(K);
+    if (Itr == end()) {
+      Itr = m_Map.emplace(K, Value()).first;
+      m_Order.emplace_back(Itr);
+    }
+    return Itr->second;
+  }
+
+  Value& operator[](Key&& K) {
+    iterator Itr = find(K);
+    if (Itr == end()) {
+      Itr = m_Map.emplace(K, Value()).first;
+      m_Order.emplace_back(Itr);
+    }
+    return Itr->second;
+  }
+
+  ///\brief Erase a mapping from this object.
+  ///
+  ///\param [in] Itr - The iterator to erase.
+  ///\param [out] Move - Move the mapped object to this pointer before erasing.
+  ///
+  void erase(const_iterator Itr, mapped_type* Move = nullptr) {
+    assert(std::find(m_Order.begin(), m_Order.end(), Itr) != m_Order.end());
+    for (auto Otr = m_Order.begin(), End = m_Order.end(); Otr != End; ++Otr) {
+      if (Itr == *Otr) {
+        m_Order.erase(Otr);
+        break;
+      }
+    }
+    assert(std::find(m_Order.begin(), m_Order.end(), Itr) == m_Order.end());
+    if (Move) *Move = std::move(Itr->second);
+    m_Map.erase(Itr);
+  }
+
+  iterator find(const Key& K) { return m_Map.find(K); }
+  const_iterator find(const Key& K) const { return m_Map.find(K); }
+
+  iterator end() { return m_Map.end(); }
+  const_iterator end() const { return m_Map.end(); }
+
+  void swap(OrderedMap& Other) {
+    m_Map.swap(Other.m_Map);
+    m_Order.swap(Other.m_Order);
+  }
+
+  void clear() {
+    m_Map.clear();
+    m_Order.clear();
+  }
+
+  bool empty() const {
+    assert(m_Map.empty() == m_Order.empty() && "Not synchronized");
+    return m_Order.empty();
+  }
+
+  void size() const {
+    assert(m_Map.size() == m_Order.size() && "Not synchronized");
+    return m_Order.size();
+  }
+
+  const order_t& ordered() const { return m_Order; }
+  order_t& ordered() { return m_Order; }
+};
+
+} // namespace utils
+} // namespace cling
+
+#endif // CLING_PLATFORM_H

--- a/lib/Interpreter/IncrementalExecutor.cpp
+++ b/lib/Interpreter/IncrementalExecutor.cpp
@@ -358,18 +358,17 @@ bool IncrementalExecutor::diagnoseUnresolvedSymbols(llvm::StringRef trigger,
     return false;
 
   llvm::SmallVector<llvm::Function*, 128> funcsToFree;
-  for (std::set<std::string>::const_iterator i = m_unresolvedSymbols.begin(),
-         e = m_unresolvedSymbols.end(); i != e; ++i) {
+  for (const std::string& sym : m_unresolvedSymbols) {
 #if 0
     // FIXME: This causes a lot of test failures, for some reason it causes
     // the call to HandleMissingFunction to be elided.
     unsigned diagID = m_Diags.getCustomDiagID(clang::DiagnosticsEngine::Error,
                                               "%0 unresolved while jitting %1");
     (void)diagID;
-    //m_Diags.Report(diagID) << *i << funcname; // TODO: demangle the names.
+    //m_Diags.Report(diagID) << sym << funcname; // TODO: demangle the names.
 #endif
 
-    cling::errs() << "IncrementalExecutor::executeFunction: symbol '" << *i
+    cling::errs() << "IncrementalExecutor::executeFunction: symbol '" << sym
                   << "' unresolved while linking ";
     if (trigger.find(utils::Synthesize::UniquePrefix) != llvm::StringRef::npos)
       cling::errs() << "[cling interface function]";
@@ -383,7 +382,7 @@ bool IncrementalExecutor::diagnoseUnresolvedSymbols(llvm::StringRef trigger,
     cling::errs() << "!\n";
 
     // Be helpful, demangle!
-    std::string demangledName = platform::Demangle(*i);
+    std::string demangledName = platform::Demangle(sym);
     if (!demangledName.empty()) {
        cling::errs()
           << "You are probably missing the definition of "

--- a/lib/Interpreter/IncrementalExecutor.h
+++ b/lib/Interpreter/IncrementalExecutor.h
@@ -22,7 +22,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include <vector>
-#include <set>
+#include <unordered_set>
 #include <map>
 #include <memory>
 #include <atomic>
@@ -126,7 +126,7 @@ namespace cling {
 
     ///\brief Set of the symbols that the JIT couldn't resolve.
     ///
-    std::set<std::string> m_unresolvedSymbols;
+    std::unordered_set<std::string> m_unresolvedSymbols;
 
 #if 0 // See FIXME in IncrementalExecutor.cpp
     ///\brief The diagnostics engine, printing out issues coming from the

--- a/lib/Interpreter/IncrementalExecutor.h
+++ b/lib/Interpreter/IncrementalExecutor.h
@@ -64,7 +64,20 @@ namespace cling {
     /// The object is registered first as an CXAAtExitElement and then cling
     /// takes the control of it's destruction.
     ///
-    struct CXAAtExitElement {
+    class CXAAtExitElement {
+      ///\brief The function to be called.
+      ///
+      void (*m_Func)(void*);
+
+      ///\brief The single argument passed to the function.
+      ///
+      void* m_Arg;
+
+      ///\brief The module whose unloading will trigger the call to this atexit
+      /// function.
+      ///
+      const llvm::Module* m_FromM;
+    public:
       ///\brief Constructs an element, whose destruction time will be managed by
       /// the interpreter. (By registering a function to be called by exit
       /// or when a shared library is unloaded.)
@@ -87,18 +100,8 @@ namespace cling {
                        const llvm::Module* fromM):
         m_Func(func), m_Arg(arg), m_FromM(fromM) {}
 
-      ///\brief The function to be called.
-      ///
-      void (*m_Func)(void*);
-
-      ///\brief The single argument passed to the function.
-      ///
-      void* m_Arg;
-
-      ///\brief The module whose unloading will trigger the call to this atexit
-      /// function.
-      ///
-      const llvm::Module* m_FromM;
+      void operator () () const { (*m_Func)(m_Arg); }
+      const llvm::Module* getModule() const { return m_FromM; }
     };
 
     ///\brief Atomic used as a spin lock to protect the access to m_AtExitFuncs

--- a/test/CodeUnloading/AtExit.C
+++ b/test/CodeUnloading/AtExit.C
@@ -35,6 +35,20 @@ at_quick_exit(atexit_2);
 // Make sure at_quick_exit is resolved correctly (mangling issues on gcc < 5)
 // CHECK-NEXT: atexit_2
 
+// Test reverse ordering in a single transaction.
+static void atexitA() { printf("atexitA\n"); }
+static void atexitB() { printf("atexitB\n"); }
+static void atexitC() { printf("atexitC\n"); }
+{
+  std::atexit(atexitA);
+  std::atexit(atexitB);
+  std::atexit(atexitC);
+}
+.undo
+// CHECK-NEXT: atexitC
+// CHECK-NEXT: atexitB
+// CHECK-NEXT: atexitA
+
 atexit(atexit_3);
 
 cling::Interpreter * gChild = 0;
@@ -53,9 +67,58 @@ static void atexit_f() {
 }
 at_quick_exit(atexit_f);
 
+void atExit0 () {
+  printf("atExit0\n");
+}
+void atExit1 () {
+  printf("atExit1\n");
+}
+void atExit2 () {
+  printf("atExit2\n");
+}
+void atExitA () {
+  printf("atExitA\n");
+  std::atexit(&atExit0);
+}
+void atExitB () {
+  printf("atExitB\n");
+  std::atexit(&atExit1);
+  std::atexit(&atExit2);
+}
+// Recursion in a Transaction
+{
+  std::atexit(&atExitA);
+  std::atexit(&atExitB);
+}
+.undo
+// CHECK-NEXT: atExitB
+// CHECK-NEXT: atExit2
+// CHECK-NEXT: atExit1
+// CHECK-NEXT: atExitA
+// CHECK-NEXT: atExit0
+
+// Recusion at shutdown
+struct ShutdownRecursion {
+  static void DtorAtExit0() { printf("ShutdownRecursion0\n"); }
+  static void DtorAtExit1() { printf("ShutdownRecursion1\n"); }
+  static void DtorAtExit2() { printf("ShutdownRecursion2\n"); }
+  ~ShutdownRecursion() {
+    printf("~ShutdownRecursion\n");
+    atexit(&DtorAtExit0);
+    atexit(&DtorAtExit1);
+    atexit(&DtorAtExit2);
+  }
+} Out;
+
 // expected-no-diagnostics
 .q
 
 // Reversed registration order
+
+// CHECK-NEXT: ~ShutdownRecursion
+// CHECK-NEXT: ShutdownRecursion2
+// CHECK-NEXT: ShutdownRecursion1
+// CHECK-NEXT: ShutdownRecursion0
+
 // CHECK-NEXT: atexit_f true
 // CHECK-NEXT: atexit_3


### PR DESCRIPTION
IncrementalExecutor assumes that no atexit functions will ever be registered by the currently executing atexit function. This assumption is wrong and against the standard.

Additionally the implementation is somewhat inefficient in memory usage using an **llvm::SmallVector<128, CXAAtExitElement>** to store the registered functions, with each **CXAAtExitElement** holding a pointer to the **llvm::Module** that created it.

Linearly traversing the list and removing elements also never really releases the memory associated with a registered function.