### PR TITLE
Add support C++1z for Jupyter kernel

### DIFF
--- a/tools/Jupyter/README.md
+++ b/tools/Jupyter/README.md
@@ -14,10 +14,11 @@ To install the kernel with sources in src/tools/cling:
     pip install -e .
     # or: pip3 install -e .
 
-    # register the kernelspec for C++17/C++14/C++11:
+    # register the kernelspec for C++17/C++1z/C++14/C++11:
     # the user can install whichever kernel(s) they
     # wish:
     jupyter-kernelspec install [--user] cling-cpp17
+    jupyter-kernelspec install [--user] cling-cpp1z
     jupyter-kernelspec install [--user] cling-cpp14
     jupyter-kernelspec install [--user] cling-cpp11
 

--- a/tools/Jupyter/kernel/cling-cpp1z/kernel.json
+++ b/tools/Jupyter/kernel/cling-cpp1z/kernel.json
@@ -1,0 +1,9 @@
+{
+  "display_name": "C++1z",
+  "argv": [
+      "jupyter-cling-kernel",
+      "-f",
+      "{connection_file}",
+      "--std=c++1z"
+  ]
+}

--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -92,8 +92,8 @@ class ClingKernel(Kernel):
     flush_interval = Float(0.25, config=True)
 
     std = CaselessStrEnum(default_value='c++11',
-            values = ['c++11', 'c++14', 'c++17'],
-            help="C++ standard to use, either c++17, c++14 or c++11").tag(config=True);
+            values = ['c++11', 'c++14', 'c++1z', 'c++17'],
+            help="C++ standard to use, either c++17, c++1z, c++14 or c++11").tag(config=True);
 
     def __init__(self, **kwargs):
         super(ClingKernel, self).__init__(**kwargs)


### PR DESCRIPTION
When run C++17 kernel in Jupyter notebook cause some errors
due to currently clang-5.0 in https://root.cern.ch/download/cling/ is not
support c++17.
So add support to C++1z for Jupyter kernel and we can try some new
features in Jupyter notebook.

for avoiding following error:

[I 05:46:38.253 NotebookApp] Kernel restarted:
d3413fa0-7046-4b63-912b-a286610eacc1
error: invalid value 'c++17' in '-std=c++17'
note: use 'c++98' or 'c++03' for 'ISO C++ 1998 with amendments' standard
note: use 'gnu++98' or 'gnu++03' for 'ISO C++ 1998 with amendments and
GNU extensions' standard
note: use 'c++11' for 'ISO C++ 2011 with amendments' standard
note: use 'gnu++11' for 'ISO C++ 2011 with amendments and GNU
extensions' standard
note: use 'c++14' for 'ISO C++ 2014 with amendments' standard
note: use 'gnu++14' for 'ISO C++ 2014 with amendments and GNU
extensions' standard
note: use 'c++1z' for 'Working draft for ISO C++ 2017' standard
note: use 'gnu++1z' for 'Working draft for ISO C++ 2017 with GNU
extensions' standard