### PR TITLE
[Fix #195] Add "language" field to kernel.json

### DIFF
--- a/tools/Jupyter/kernel/cling-cpp11/kernel.json
+++ b/tools/Jupyter/kernel/cling-cpp11/kernel.json
@@ -5,5 +5,6 @@
       "-f",
       "{connection_file}",
       "--std=c++11"
-  ]
+  ],
+  "language": "C++"
 }

--- a/tools/Jupyter/kernel/cling-cpp14/kernel.json
+++ b/tools/Jupyter/kernel/cling-cpp14/kernel.json
@@ -5,5 +5,6 @@
       "-f",
       "{connection_file}",
       "--std=c++14"
-  ]
+  ],
+  "language": "C++"
 }

--- a/tools/Jupyter/kernel/cling-cpp17/kernel.json
+++ b/tools/Jupyter/kernel/cling-cpp17/kernel.json
@@ -5,5 +5,6 @@
       "-f",
       "{connection_file}",
       "--std=c++17"
-  ]
+  ],
+  "language": "C++"
 }

--- a/tools/Jupyter/kernel/cling-cpp1z/kernel.json
+++ b/tools/Jupyter/kernel/cling-cpp1z/kernel.json
@@ -5,5 +5,7 @@
       "-f",
       "{connection_file}",
       "--std=c++1z"
-  ]
+  ],
+  "language": "C++"
+
 }


### PR DESCRIPTION
Fixing compatibility with Hydrogen (and possibly sth. else since "language" is an ubiquitous field for kernel.json)
#195  and  nteract/hydrogen#1129