### PR TITLE
Fix cling not found in jupyter kernel when `which cling` is a link to relative path (e.g. ../Cellar/cling/...)

### DIFF
--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -99,6 +99,8 @@ class ClingKernel(Kernel):
         super(ClingKernel, self).__init__(**kwargs)
         try:
             whichCling = os.readlink(shutil.which('cling'))
+            if not os.path.isabs(whichCling):
+                whichCling = os.path.join(os.path.dirname(shutil.which('cling')), whichCling)
         except OSError as e:
             #If cling is not a symlink try a regular file
             #readlink returns POSIX error EINVAL (22) if the


### PR DESCRIPTION
On my mac, `ls -al /usr/local/bin/clang` shows `/usr/local/bin/cling -> ../Cellar/cling/0.5/bin/cling`, thus the code will use `../Cellar/cling/0.5/bin/cling` as the actual path of cling. However, cwd now is no longer `/usr/local/bin`.