### PR TITLE
Fix cling kernel path issues 

### DIFF
--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -99,6 +99,7 @@ class ClingKernel(Kernel):
         super(ClingKernel, self).__init__(**kwargs)
         try:
             whichCling = os.readlink(shutil.which('cling'))
+            whichCling = os.path.join(os.path.dirname(shutil.which("cling")), whichCling)
         except OSError as e:
             #If cling is not a symlink try a regular file
             #readlink returns POSIX error EINVAL (22) if the
@@ -112,7 +113,7 @@ class ClingKernel(Kernel):
             whichCling = find_executable('cling')
 
         if whichCling:
-            clingInstDir = os.path.dirname(os.path.dirname(whichCling))
+            clingInstDir = os.path.abspath(os.path.dirname(os.path.dirname(whichCling)))
             llvmResourceDir = clingInstDir
         else:
             raise RuntimeError('Cannot find cling in $PATH. No cling, no fun.')

--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -123,7 +123,15 @@ class ClingKernel(Kernel):
                 self.libclingJupyter = ctypes.CDLL(clingInstDir + "/lib/libclingJupyter." + ext,
                                                    mode = ctypes.RTLD_GLOBAL)
                 break
-
+                
+        for ext in ['so', 'dylib', 'dll']:
+            libFilename = clingInstDir + "/libexec/lib/libclingJupyter." + ext
+            if os.access(libFilename, os.R_OK):
+                self.libclingJupyter = ctypes.CDLL(
+                    clingInstDir + "/libexec/lib/libclingJupyter." + ext, mode=ctypes.RTLD_GLOBAL
+                )
+                break
+                
         if not getattr(self, 'libclingJupyter', None):
             raise RuntimeError('Cannot find ' + clingInstDir + '/lib/libclingJupyter.{so,dylib,dll}')
 

--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -118,21 +118,18 @@ class ClingKernel(Kernel):
         else:
             raise RuntimeError('Cannot find cling in $PATH. No cling, no fun.')
 
-        for ext in ['so', 'dylib', 'dll']:
-            libFilename = clingInstDir + "/lib/libclingJupyter." + ext
-            if os.access(libFilename, os.R_OK):
-                self.libclingJupyter = ctypes.CDLL(clingInstDir + "/lib/libclingJupyter." + ext,
-                                                   mode = ctypes.RTLD_GLOBAL)
-                break
-                
-        for ext in ['so', 'dylib', 'dll']:
-            libFilename = clingInstDir + "/libexec/lib/libclingJupyter." + ext
-            if os.access(libFilename, os.R_OK):
-                self.libclingJupyter = ctypes.CDLL(
-                    clingInstDir + "/libexec/lib/libclingJupyter." + ext, mode=ctypes.RTLD_GLOBAL
-                )
-                break
-                
+        for libFolder in ["/lib/libclingJupyter.", "/libexec/lib/libclingJupyter."]:
+
+            for ext in ['so', 'dylib', 'dll']:
+                libFilename = clingInstDir + libFolder + ext
+                if os.access(libFilename, os.R_OK):
+                    self.libclingJupyter = ctypes.CDLL(clingInstDir + libFolder + ext,
+                                                    mode = ctypes.RTLD_GLOBAL)
+                    break
+            else:
+                continue
+            break
+
         if not getattr(self, 'libclingJupyter', None):
             raise RuntimeError('Cannot find ' + clingInstDir + '/lib/libclingJupyter.{so,dylib,dll}')
 


### PR DESCRIPTION
This PR is required to get cling installed using brew (`brew install cling`) working as a jupyter notebook kernel. 

```bash
$ ls -al /usr/local/Cellar/cling/0.5_1/
total 80
drwxr-xr-x  8 $USER  admin    272 Dec 11 14:36 .
drwxr-xr-x  3 $USER  admin    102 Dec 11 14:36 ..
drwxr-xr-x  3 $USER  admin    102 Nov  2 10:29 .brew
-rw-r--r--  1 $USER  admin    609 Dec 11 14:36 INSTALL_RECEIPT.json
-rw-r--r--  1 $USER  admin  26800 Nov  2 10:29 LICENSE.TXT
-rw-r--r--  1 $USER  admin   4483 Nov  2 10:29 README.md
drwxr-xr-x  3 $USER  admin    102 Nov  2 10:29 bin
drwxr-xr-x  7 $USER  admin    238 Nov  2 10:29 libexec
```

```bash
ls -al /usr/local/Cellar/cling/0.5_1/libexec
total 0
drwxr-xr-x    7 $USER  admin   238 Nov  2 10:29 .
drwxr-xr-x    8 $USER  admin   272 Dec 11 14:36 ..
drwxr-xr-x   64 $USER  admin  2176 Nov  2 10:29 bin
drwxr-xr-x    7 $USER  admin   238 Nov  2 10:29 include
drwxr-xr-x  169 $USER  admin  5746 Nov  2 10:29 lib
drwxr-xr-x    4 $USER  admin   136 Nov  2 10:29 libexec
drwxr-xr-x    7 $USER  admin   238 Nov  2 10:29 share
```