### PR TITLE
Cuda host side

### DIFF
--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -58,6 +58,7 @@ namespace cling {
     unsigned HasOutput : 1;
     unsigned Verbose : 1;
     unsigned CxxModules : 1;
+    unsigned CUDA : 1;
     /// \brief The output path of any C++ PCMs we're building on demand.
     /// Equal to ModuleCachePath in the HeaderSearchOptions.
     std::string CachePath;

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -1116,6 +1116,15 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       Buffer = llvm::MemoryBuffer::getMemBuffer("/*CLING DEFAULT MEMBUF*/;\n");
     const_cast<SrcMgr::ContentCache*>(MainFileCC)->setBuffer(std::move(Buffer));
 
+    // Create TargetInfo for the other side of CUDA and OpenMP compilation.
+    if ((CI->getLangOpts().CUDA || CI->getLangOpts().OpenMPIsDevice) &&
+        !CI->getFrontendOpts().AuxTriple.empty()) {
+          auto TO = std::make_shared<TargetOptions>();
+          TO->Triple = CI->getFrontendOpts().AuxTriple;
+          TO->HostTriple = CI->getTarget().getTriple().str();
+          CI->setAuxTarget(TargetInfo::CreateTargetInfo(CI->getDiagnostics(), TO));
+    }
+
     // Set up the preprocessor
     CI->createPreprocessor(TU_Complete);
     Preprocessor& PP = CI->getPreprocessor();

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -885,6 +885,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       argvCompile.push_back("-x");
       argvCompile.push_back( "c++");
     }
+
     if (COpts.DefaultLanguage()) {
       // By default, set the standard to what cling was compiled with.
       // clang::driver::Compilation will do various things while initializing
@@ -897,6 +898,13 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
         default: llvm_unreachable("Unrecognized C++ version");
       }
     }
+
+    // This argument starts the cling instance with the x86 target. Otherwise,
+    // the first job in the joblist starts the cling instance with the nvptx
+    // target.
+    if(COpts.CUDA)
+      argvCompile.push_back("--cuda-host-only");
+
     // argv[0] already inserted, get the rest
     argvCompile.insert(argvCompile.end(), argv+1, argv + argc);
 

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -257,6 +257,14 @@ namespace cling {
       setupCallbacks(*this, parentInterp);
     }
 
+    if(m_Opts.CompilerOpts.CUDA){
+       if(m_DyLibManager->loadLibrary("libcudart.so", true) ==
+         cling::DynamicLibraryManager::LoadLibResult::kLoadLibNotFound){
+           llvm::errs() << "Error: libcudart.so not found!\n" <<
+             "Please add the cuda lib path to LD_LIBRARY_PATH or set it via -L argument.\n";
+       }
+    }
+
     llvm::SmallVector<IncrementalParser::ParseResultTransaction, 2>
       IncrParserTransactions;
     if (!m_IncrParser->Initialize(IncrParserTransactions, parentInterp)) {

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -100,7 +100,7 @@ static const char kNoStdInc[] = "-nostdinc";
 CompilerOptions::CompilerOptions(int argc, const char* const* argv)
     : Language(false), ResourceDir(false), SysRoot(false), NoBuiltinInc(false),
       NoCXXInc(false), StdVersion(false), StdLib(false), HasOutput(false),
-      Verbose(false), CxxModules(false) {
+      Verbose(false), CxxModules(false), CUDA(false) {
   if (argc && argv) {
     // Preserve what's already in Remaining, the user might want to push args
     // to clang while still using main's argc, argv
@@ -126,7 +126,9 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
       // case options::OPT_d_Flag:
       case options::OPT_E:
       case options::OPT_o: HasOutput = true; break;
-      case options::OPT_x: Language = true; break;
+      case options::OPT_x: Language = true;
+                           CUDA = llvm::StringRef(arg->getValue()) == "cuda";
+                           break;
       case options::OPT_resource_dir: ResourceDir = true; break;
       case options::OPT_isysroot: SysRoot = true; break;
       case options::OPT_std_EQ: StdVersion = true; break;
@@ -158,7 +160,7 @@ bool CompilerOptions::DefaultLanguage(const LangOptions* LangOpts) const {
   // Also don't set up the defaults when language is explicitly set; unless
   // the language was set to generate a PCH, in which case definitely do.
   if (Language)
-    return HasOutput || (LangOpts && LangOpts->CompilingPCH);
+    return HasOutput || (LangOpts && LangOpts->CompilingPCH) || CUDA;
 
   return true;
 }

--- a/test/Driver/CUDAMode.C
+++ b/test/Driver/CUDAMode.C
@@ -1,0 +1,24 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// The Test starts the cling with the arg -xcuda and checks if the cuda mode
+// is enabled.
+// RUN: cat %s | %cling -x cuda -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda -fsyntax-only -Xclang -verify 2>&1
+// REQUIRES: cuda-runtime
+
+
+.rawInput 1
+__global__ void foo(){ int i = 3; }
+.rawInput 0
+
+cudaError error
+// CHECK: (cudaError) (cudaError::cudaSuccess) : (unsigned int) 0
+
+// expected-no-diagnostics
+.q

--- a/test/Interfaces/invocationFlags.C
+++ b/test/Interfaces/invocationFlags.C
@@ -36,12 +36,19 @@ COpts.NoBuiltinInc
 // CHECK-NEXT: (unsigned int) 1
 COpts.NoCXXInc
 // CHECK-NEXT: (unsigned int) 0
+COpts.CUDA
+// CHECK-NEXT: (unsigned int) 0
+
+COpts.DefaultLanguage()
+// CHECK-NEXT: false
 
 // library caller options: arguments passed as is
 COpts.Remaining
 // CHECK-NEXT: {{.*}} { "progname", "-", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-nobuiltininc", "-v", "FileToExecuteB", "-L/Path/To/Libs", "-lTest" }
 
+argv[2] = "-xcuda";
 argv[6] = "-nostdinc++";
+
 cling::InvocationOptions IOpts(argc, argv);
 IOpts.Inputs
 // CHECK-NEXT: {{.*}} { "-", "FileToExecuteA", "FileToExecuteB" }
@@ -60,12 +67,18 @@ IOpts.CompilerOpts.NoBuiltinInc
 // CHECK-NEXT: (unsigned int) 0
 IOpts.CompilerOpts.NoCXXInc
 // CHECK-NEXT: (unsigned int) 1
+IOpts.CompilerOpts.CUDA
+// CHECK-NEXT: (unsigned int) 1
+
+// if the language is cuda, it should set automatically the c++ standard
+IOpts.CompilerOpts.DefaultLanguage()
+// CHECK-NEXT: true
 
 // user options from main: filtered by cling (no '-')
 IOpts.CompilerOpts.Remaining
 
 // Windows translates -nostdinc++ to -nostdinc++. Ignore that fact for the test.
-// CHECK-NEXT: {{.*}} { "progname", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", {{.*}}, "-v", "FileToExecuteB" }
+// CHECK-NEXT: {{.*}} { "progname", "-xcuda", "FileToExecuteA", "-isysroot", "APAth", {{.*}}, "-v", "FileToExecuteB" }
 
 // expected-no-diagnostics
 .q

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -314,6 +314,9 @@ if os.path.isdir(config.llvm_src_root + '/tools/clang') and \
    os.path.isdir(config.llvm_src_root + '/tools/cling'):
     config.available_features.add('vanilla-cling')
 
+if lit.util.which('libcudart.so', config.environment.get('LD_LIBRARY_PATH','')) is not None:
+  config.available_features.add('cuda-runtime')
+
 # Loadable module
 # FIXME: This should be supplied by Makefile or autoconf.
 #if sys.platform in ['win32', 'cygwin']:


### PR DESCRIPTION
This commits allows to enable the cuda mode of the clang compiler instance and translate cuda runtime code on the host side.

Follow functions will added:
- set the CUDA AuxTarget, if CUDA is detected
- detect the CUDA language at CompilerOptions and set new Flag
- add Argument --cuda-host-only if the Argument -xclang is set at start of clang
- set default c++ standard, if language is cuda
- load libcudart.so at start of cling -xcuda (at the moment, just linux is supported)