### PR TITLE
fix up type printing for fully qualified templates

### DIFF
--- a/lib/Interpreter/ValuePrinter.cpp
+++ b/lib/Interpreter/ValuePrinter.cpp
@@ -79,8 +79,10 @@ static std::string enclose(std::string Mid, const char* Begin,
 static std::string enclose(const clang::QualType& Ty, clang::ASTContext& C,
                            const char* Begin = "(", const char* End = "*)",
                            size_t Hint = 3) {
-  return enclose(cling::utils::TypeName::GetFullyQualifiedName(Ty, C),
-                 Begin, End, Hint);
+  clang::PrintingPolicy Policy(C.getPrintingPolicy());
+  Policy.PolishForDeclaration = true;
+  std::string Name = Ty.getAsString(Policy);
+  return enclose(Name, Begin, End, Hint);
 }
 
 static clang::QualType


### PR DESCRIPTION
We had some issues with not fully qualified template arguments in the value printer (the xeus-cling project uses derived functions from ValuePrinter).

We found this change to fix our issues. 

Do you see any drawbacks?