### PR TITLE
Interpreter and other classes have been modified for support null args

### DIFF
--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -37,7 +37,8 @@ namespace cling {
     ///\param [in] argv - arguments
     ///\param [out] Inputs - save all arguments that are inputs/files here
     ///
-    void Parse(int argc, const char* const argv[],
+    void Parse(int argc, 
+               const char* const * argv,
                std::vector<std::string>* Inputs = nullptr);
 
     ///\brief By default clang will try to set up an Interpreter with features
@@ -72,7 +73,7 @@ namespace cling {
 
   class InvocationOptions {
   public:
-    InvocationOptions(int argc, const char* const argv[]);
+    InvocationOptions(int argc = 0, const char* const * argv = nullptr);
 
     /// \brief A line starting with this string is assumed to contain a
     ///        directive for the MetaProcessor. Defaults to "."

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -828,7 +828,11 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
 
     const size_t argc = COpts.Remaining.size();
     const char* const* argv = &COpts.Remaining[0];
-    std::vector<const char*> argvCompile(argv, argv+1);
+    std::vector<const char*> argvCompile;
+    if(argc && argv) {
+        argvCompile = std::vector<const char*>(argv, argv+1);
+    }
+    
     argvCompile.reserve(argc+5);
 
     // Variables for storing the memory of the C-string arguments.
@@ -910,7 +914,10 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     argvCompile.insert(argvCompile.end(), argv+1, argv + argc);
 
     // Add host specific includes, -resource-dir if necessary, and -isysroot
-    std::string ClingBin = GetExecutablePath(argv[0]);
+    std::string ClingBin;
+    if(argv) {
+        ClingBin = GetExecutablePath(argv[0]);
+    }
     AddHostArguments(ClingBin, argvCompile, LLVMDir, COpts);
 
     // Be explicit about the stdlib on OS X
@@ -948,7 +955,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // COFF format currently needs a few changes in LLVM to function properly.
     TheTriple.setObjectFormat(llvm::Triple::COFF);
 #endif
-    clang::driver::Driver Drvr(argv[0], TheTriple.getTriple(), *Diags);
+    clang::driver::Driver Drvr(ClingBin, TheTriple.getTriple(), *Diags);
     //Drvr.setWarnMissingInput(false);
     Drvr.setCheckInputsExist(false); // think foo.C(12)
     llvm::ArrayRef<const char*>RF(&(argvCompile[0]), argvCompile.size());


### PR DESCRIPTION
This patch permit to use interpreter without give the argc(0) and argv(nullptr)