### PR TITLE
Unique cuda module ctor name

### DIFF
--- a/lib/Interpreter/BackendPasses.cpp
+++ b/lib/Interpreter/BackendPasses.cpp
@@ -186,7 +186,11 @@ void BackendPasses::CreatePasses(llvm::Module& M, int OptLevel)
   m_MPM[OptLevel].reset(new legacy::PassManager());
 
   m_MPM[OptLevel]->add(new KeepLocalGVPass());
-  m_MPM[OptLevel]->add(new UniqueCUDAStructorName());
+  // The function __cuda_module_ctor and __cuda_module_dtor will just generated,
+  // if a CUDA fatbinary file exist. Without file path there is no need for the
+  // function pass.
+  if(!m_CGOpts.CudaGpuBinaryFileNames.empty())
+    m_MPM[OptLevel]->add(new UniqueCUDAStructorName());
   m_MPM[OptLevel]->add(createTargetTransformInfoWrapperPass(
                                                    m_TM.getTargetIRAnalysis()));
 

--- a/lib/Interpreter/BackendPasses.cpp
+++ b/lib/Interpreter/BackendPasses.cpp
@@ -87,8 +87,8 @@ namespace {
         NewFunctionName.append(ModuleName);
 
         for (size_t i = 0; i < NewFunctionName.size(); ++i) {
-          // Replace everything that's not [a-zA-Z0-9._] with a _. This set happens
-          // to be the set of C preprocessing numbers.
+          // Replace everything that is not [a-zA-Z0-9._] with a _. This set
+          // happens to be the set of C preprocessing numbers.
           if (!isPreprocessingNumberBody(NewFunctionName[i]))
             NewFunctionName[i] = '_';
         }
@@ -106,7 +106,7 @@ namespace {
 
     bool runOnModule(Module &M) override {
       bool ret = false;
-      StringRef ModuleName = M.getName();
+      const StringRef ModuleName = M.getName();
       for (auto &&F: M)
         ret |= runOnFunction(F, ModuleName);
       return ret;

--- a/lib/Interpreter/BackendPasses.cpp
+++ b/lib/Interpreter/BackendPasses.cpp
@@ -78,11 +78,11 @@ namespace {
   class UniqueCUDAStructorName : public ModulePass {
     static char ID;
 
-    bool runOnGlobal(GlobalValue& GV, const StringRef ModuleName){
-      if(GV.hasName() && (GV.getName() == "__cuda_module_ctor"
-          || GV.getName() == "__cuda_module_dtor") ){
+    bool runOnFunction(Function& F, const StringRef ModuleName){
+      if(F.hasName() && (F.getName() == "__cuda_module_ctor"
+          || F.getName() == "__cuda_module_dtor") ){
         llvm::SmallString<128> NewFunctionName;
-        NewFunctionName.append(GV.getName());
+        NewFunctionName.append(F.getName());
         NewFunctionName.append("_");
         NewFunctionName.append(ModuleName);
 
@@ -93,7 +93,7 @@ namespace {
             NewFunctionName[i] = '_';
         }
 
-        GV.setName(NewFunctionName);
+        F.setName(NewFunctionName);
 
         return true;
       }
@@ -108,7 +108,7 @@ namespace {
       bool ret = false;
       StringRef ModuleName = M.getName();
       for (auto &&F: M)
-        ret |= runOnGlobal(F, ModuleName);
+        ret |= runOnFunction(F, ModuleName);
       return ret;
     }
   };

--- a/test/CodeGeneration/CUDACtorDtor.C
+++ b/test/CodeGeneration/CUDACtorDtor.C
@@ -51,11 +51,9 @@ for(auto &I : *M2){
 }
 
 // Check if the ctor and dtor of the two modules are different.
-ctor1 != ctor2
-// expected-note {{use '|=' to turn this inequality comparison into an or-assignment}}
+ctor1 != ctor2 // expected-note {{use '|=' to turn this inequality comparison into an or-assignment}}
 // CHECK: (bool) true
-dtor1 != dtor2
-// expected-note {{use '|=' to turn this inequality comparison into an or-assignment}}
+dtor1 != dtor2 // expected-note {{use '|=' to turn this inequality comparison into an or-assignment}}
 // CHECK: (bool) true
 
 // Check if the ctor symbol starts with the correct prefix.
@@ -68,6 +66,4 @@ std::string expectedDtorPrefix = "__cuda_module_dtor_cling_module_";
 dtor1.compare(0, expectedDtorPrefix.length(), expectedDtorPrefix)
 // CHECK: (int) 0
 
-
-// expected-no-diagnostics
 .q

--- a/test/CodeGeneration/CUDACtorDtor.C
+++ b/test/CodeGeneration/CUDACtorDtor.C
@@ -18,7 +18,7 @@
 #include "llvm/IR/Module.h"
 #include <iostream>
 
-// Compare the the cuda module ctor and dtor of two random modules.
+// Compare the cuda module ctor and dtor of two random modules.
 std::string ctor1, ctor2, dtor1, dtor2;
 
 auto M1 = gCling->getLatestTransaction()->getModule();
@@ -36,7 +36,7 @@ for(auto &I : *M1){
 
 auto M2 = gCling->getLatestTransaction()->getModule();
 
-// The last module should be another, because of the for loop.
+// The two modules should have different names, because of the for loop.
 M1->getName() != M2->getName()
 // CHECK: (bool) true
 

--- a/test/CodeGeneration/CUDACtorDtor.C
+++ b/test/CodeGeneration/CUDACtorDtor.C
@@ -37,7 +37,7 @@ for(auto &I : *M1){
 auto M2 = gCling->getLatestTransaction()->getModule();
 
 // The two modules should have different names, because of the for loop.
-M1->getName() != M2->getName()
+M1->getName().str() != M2->getName().str()
 // CHECK: (bool) true
 
 for(auto &I : *M2){

--- a/test/CodeGeneration/CUDACtorDtor.C
+++ b/test/CodeGeneration/CUDACtorDtor.C
@@ -1,0 +1,62 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// The Test checks, if the symbols __cuda_module_ctor and __cuda_module_dtor are
+// unique for every module. Attention, for a working test case, a cuda 
+// fatbinary is necessary.
+// RUN: cat %s | %cling -x cuda -Xclang -verify 2>&1 | FileCheck %s
+// REQUIRES: cuda-runtime
+
+#include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/Transaction.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include <iostream>
+
+// It compares the cuda module ctor and dtor of two random modules.
+std::string ctor1, ctor2, dtor1, dtor2;
+
+auto M = gCling->getLatestTransaction()->getModule();
+
+for(auto I = M->begin(), E = M->end(); I != E; ++I){
+  if((*I).getName().startswith_lower("__cuda_module_ctor_")){
+    ctor1 = (*I).getName().str();
+  }
+
+  if((*I).getName().startswith_lower("__cuda_module_dtor_")){
+    dtor1 = (*I).getName().str();
+  }
+}
+
+// The last module should be another, because of the for loop.
+M = gCling->getLatestTransaction()->getModule();
+
+for(auto I = M->begin(), E = M->end(); I != E; ++I){
+  if((*I).getName().startswith_lower("__cuda_module_ctor_")){
+    ctor2 = (*I).getName().str();
+  }
+
+  if((*I).getName().startswith_lower("__cuda_module_dtor_")){
+    dtor2 = (*I).getName().str();
+  }
+}
+
+// Check if the ctor and dtor of the two modules are different.
+bool result1 = ctor1 != ctor2
+// CHECK: (bool) true
+bool result2 = dtor1 != dtor2
+// CHECK: (bool) true
+
+// Check if the symbols are preprocessor compliant.
+ctor1.find("__cuda_module_ctor_cling_module_")
+// CHECK: (unsigned long) 0
+dtor1.find("__cuda_module_dtor_cling_module_")
+// CHECK: (unsigned long) 0
+
+// expected-no-diagnostics
+.q


### PR DESCRIPTION
This function pass change the symbol of the symbols __cuda_module_ctor and __cuda_module_dtor to unique symbols. It appends the module name and change the symbols to preprocessor compliant symbols.

Attention, the test case works fine, but it needs a cuda fatbinary. At the moment there is just a really ugly way to start the test with a cuda fatbinary. 

`LD_PRELOAD=/usr/local/cuda/lib64/libcudart.so cat <path_to_cling>/cling/src/tools/cling/test/CodeGeneration/CUDACtorDtor.C | <path_to_cling>/cling/build/./bin/cling --nologo -x cuda --cuda-host-only -l/usr/local/cuda/lib64/libcudart.so -Xclang -fcuda-include-gpubinary -Xclang <path_to_cling>/cling/build/bin/dummy.fatbin -Xclang -verify 2>&1 | <path_to_cling>/cling/build/./bin/FileCheck <path_to_cling>/cling/src/tools/cling/test/CodeGeneration/CUDACtorDtor.C`

In a future pull request (cuda device side), there will be code, which will handle the cuda fatbinary by the cling itself. If the cuda device side code is integrated, the testcase should works fine.