### PR TITLE
Allow cpt.py to handle double-digit version numbers

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -676,6 +676,16 @@ def cleanup():
             shutil.rmtree(os.path.join(workdir, 'Install'))
     gInCleanup = False
 
+def check_version_string_ge(vstring, min_vstring):
+    version_fields = [int(x) for x in vstring.split('.')]
+    min_versions = [int(x) for x in min_vstring.split('.')]
+    for i in range(0,len(min_versions)):
+        if version_fields[i] < min_versions[i]:
+            return False
+        elif version_fields[i] > min_versions[i]:
+            return True
+    return True
+
 
 ###############################################################################
 #            Debian specific functions (ported from debianize.sh)             #
@@ -695,7 +705,7 @@ def check_ubuntu(pkg):
             print(pkg.ljust(20) + '[OK]'.ljust(30))
     elif pkg == "cmake":
         CMAKE = os.environ.get('CMAKE', 'cmake')
-        if exec_subprocess_check_output('{cmake} --version'.format(cmake=CMAKE), '/').strip().split('\n')[0].split()[-1] < '3.4.3':
+        if not check_version_string_ge(exec_subprocess_check_output('{cmake} --version'.format(cmake=CMAKE), '/').strip().split('\n')[0].split()[-1], '3.4.3'):
             print(pkg.ljust(20) + '[OUTDATED VERSION (<3.4.3)]'.ljust(30))
         else:
             print(pkg.ljust(20) + '[OK]'.ljust(30))
@@ -975,7 +985,7 @@ def check_redhat(pkg):
             print(pkg.ljust(20) + '[OK]'.ljust(30))
     elif pkg == "cmake":
         CMAKE = os.environ.get('CMAKE', 'cmake')
-        if exec_subprocess_check_output('{cmake} --version'.format(cmake=CMAKE), '/').strip().split('\n')[0].split()[-1] < '3.4.3':
+        if not check_version_string_ge(exec_subprocess_check_output('{cmake} --version'.format(cmake=CMAKE), '/').strip().split('\n')[0].split()[-1], '3.4.3'):
             print(pkg.ljust(20) + '[OUTDATED VERSION (<3.4.3)]'.ljust(30))
         else:
             print(pkg.ljust(20) + '[OK]'.ljust(30))
@@ -1477,7 +1487,7 @@ def check_mac(pkg):
             print(pkg.ljust(20) + '[OK]'.ljust(30))
     elif pkg == "cmake":
         CMAKE = os.environ.get('CMAKE', 'cmake')
-        if exec_subprocess_check_output('{cmake} --version'.format(cmake=CMAKE), '/').strip().split('\n')[0].split()[-1] < '3.4.3':
+        if not check_version_string_ge(exec_subprocess_check_output('{cmake} --version'.format(cmake=CMAKE), '/').strip().split('\n')[0].split()[-1], '3.4.3'):
             print(pkg.ljust(20) + '[OUTDATED VERSION (<3.4.3)]'.ljust(30))
         else:
             print(pkg.ljust(20) + '[OK]'.ljust(30))


### PR DESCRIPTION
Before this commit, cpt.py attempted to determine version numbers by simply comparing strings, for example, `"3.11.1" < "3.4.3"`, but this incorrectly returns `True` in that case. This commit adds a function that splits the string into version identifiers and checks them all individually.

----------------------------------

Here is an example of the failure on my (mac) system:
```
(19:59:15) $ cmake --version
cmake version 3.11.0

CMake suite maintained and supported by Kitware (kitware.com/cmake).
(19:59:47) $ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
(20:00:07) $ ./tools/packaging/cpt.py --check-requirements
Cling Packaging Tool (CPT)
Arguments vector: ['./tools/packaging/cpt.py', '--check-requirements']

╔══════════════════════════════════════════════════════════════════════════════╗
║ cling (x86_64)                               Tue, 22 May 2018 20:00:07 -0400 ║
╚══════════════════════════════════════════════════════════════════════════════╝
Thread Model: POSIX
Operating System: Darwin
Distribution: MacOSX
Release: 17.5.0
Revision: 10.13.4
Architecture: x86_64

+-----------------------------------------------------------------------------+
| Check availability of required softwares                                    |
+-----------------------------------------------------------------------------+
git                 [OK]
cmake               [OUTDATED VERSION (<3.4.3)]
clang               [OK]
clang++             [OK]
python              [UNSUPPORTED VERSION (Python 3)]
SSL                 [SUPPORTED]

CPT will now attempt to update/install the requisite packages automatically. Make sure you have MacPorts installed.
Do you want to continue? [yes/no]: ^C

(20:00:38) $ git checkout cpt-version-strings
Switched to branch 'cpt-version-strings'
(20:00:43) $ ./tools/packaging/cpt.py --check-requirements
Cling Packaging Tool (CPT)
Arguments vector: ['./tools/packaging/cpt.py', '--check-requirements']

╔══════════════════════════════════════════════════════════════════════════════╗
║ cling (x86_64)                               Tue, 22 May 2018 19:51:22 -0400 ║
╚══════════════════════════════════════════════════════════════════════════════╝
Thread Model: POSIX
Operating System: Darwin
Distribution: MacOSX
Release: 17.5.0
Revision: 10.13.4
Architecture: x86_64

+-----------------------------------------------------------------------------+
| Check availability of required softwares                                    |
+-----------------------------------------------------------------------------+
git                 [OK]
cmake               [OK]
clang               [OK]
clang++             [OK]
python              [OK]
SSL                 [SUPPORTED]

CPT will now attempt to update/install the requisite packages automatically. Make sure you have MacPorts installed.
Do you want to continue? [yes/no]: no
```