### PR TITLE
Fix handling of Control+C and Control+D

### DIFF
--- a/lib/UserInterface/textinput/SignalHandler.cpp
+++ b/lib/UserInterface/textinput/SignalHandler.cpp
@@ -23,11 +23,6 @@ namespace textinput {
   using std::raise;
 
   void
-  SignalHandler::EmitCtrlC() {
-    raise(SIGINT);
-  }
-
-  void
   SignalHandler::EmitCtrlZ() {
 #ifndef _WIN32
     raise(SIGTSTP);

--- a/lib/UserInterface/textinput/SignalHandler.h
+++ b/lib/UserInterface/textinput/SignalHandler.h
@@ -22,7 +22,6 @@ namespace textinput {
     SignalHandler() {}
     ~SignalHandler() {}
 
-    void EmitCtrlC();
     void EmitCtrlZ();
   };
 }

--- a/lib/UserInterface/textinput/TerminalDisplayUnix.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayUnix.cpp
@@ -105,10 +105,10 @@ namespace textinput {
     TerminalDisplay(TerminalConfigUnix::Get().IsInteractive()),
     fIsAttached(false), fNColors(16), fOutputID(STDOUT_FILENO)
   {
-    if (::isatty(::fileno(stdin)) && !::isatty(fOutputID)) {
-      // Display prompt, even if stdout is going somewhere else
-      fOutputID = ::open("/dev/tty", O_WRONLY);
-      SetIsTTY(true);
+     if (::isatty(fileno(stdin)) && !::isatty(fOutputID)) {
+        // Display prompt, even if stdout is going somewhere else
+        fOutputID = ::open("/dev/tty", O_WRONLY);
+        SetIsTTY(true);
     }
 
     HandleResizeSignal(); // needs fOutputID

--- a/lib/UserInterface/textinput/TerminalDisplayWin.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayWin.cpp
@@ -35,13 +35,12 @@ namespace textinput {
         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
         FILE_ATTRIBUTE_NORMAL, NULL);
       ::GetConsoleMode(fOut, &fOldMode);
-
-      CONSOLE_SCREEN_BUFFER_INFO csbi;
-      ::GetConsoleScreenBufferInfo(fOut, &csbi);
-      fDefaultAttributes = csbi.wAttributes;
-      assert(fDefaultAttributes != 0 && "~TerminalDisplayWin broken");
     } else
       ::SetConsoleOutputCP(65001); // Force UTF-8 output
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    ::GetConsoleScreenBufferInfo(fOut, &csbi);
+    fDefaultAttributes = csbi.wAttributes;
+    assert(fDefaultAttributes != 0 && "~TerminalDisplayWin broken");
     fMyMode = fOldMode | ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT;
     HandleResizeEvent();
   }

--- a/lib/UserInterface/textinput/TerminalDisplayWin.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayWin.cpp
@@ -35,8 +35,9 @@ namespace textinput {
         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
         FILE_ATTRIBUTE_NORMAL, NULL);
       ::GetConsoleMode(fOut, &fOldMode);
-    } else
+    } else {
       ::SetConsoleOutputCP(65001); // Force UTF-8 output
+    }
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     ::GetConsoleScreenBufferInfo(fOut, &csbi);
     fDefaultAttributes = csbi.wAttributes;

--- a/lib/UserInterface/textinput/Text.h
+++ b/lib/UserInterface/textinput/Text.h
@@ -71,7 +71,7 @@ namespace textinput {
 
     Text& operator+=(char C) { insert(length(), C); return *this; }
     Text& operator=(const std::string& S) {
-      // Assing string S to this, initialize with default colors.
+      // Assign string S to this, initialize with default colors.
       fColor.clear();
       fColor.resize(S.length());
       fString = S;

--- a/lib/UserInterface/textinput/TextInput.cpp
+++ b/lib/UserInterface/textinput/TextInput.cpp
@@ -63,7 +63,7 @@ namespace textinput {
 
     // Signal displays that the input got taken.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-             std::mem_fun(&Display::NotifyResetInput));
+             [](Display *D) { return D->NotifyResetInput(); });
 
     ReleaseInputOutput();
 
@@ -157,7 +157,7 @@ namespace textinput {
                && Cmd.GetCommandID() == Editor::kCmdWindowResize) {
       std::for_each(fContext->GetDisplays().begin(),
                     fContext->GetDisplays().end(),
-                    std::mem_fun(&Display::NotifyWindowChange));
+                    [](Display *D) { return D->NotifyWindowChange(); });
     } else {
       if (!in.IsRaw() && in.GetExtendedInput() == InputData::kEIEOF) {
         fLastReadResult = kRREOF;
@@ -168,7 +168,7 @@ namespace textinput {
           // Signal displays that an error has occurred.
           std::for_each(fContext->GetDisplays().begin(),
                         fContext->GetDisplays().end(),
-                        std::mem_fun(&Display::NotifyError));
+                        [](Display *D) { return D->NotifyError(); });
         } else if (Cmd.GetKind() == Editor::kCKCommand
                    && (Cmd.GetCommandID() == Editor::kCmdEnter ||
                        Cmd.GetCommandID() == Editor::kCmdHistReplay)) {
@@ -192,7 +192,7 @@ namespace textinput {
 
     if (oldCursorPos != fContext->GetCursor()) {
       std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                    std::mem_fun(&Display::NotifyCursorChange));
+                    [](Display *D) { return D->NotifyCursorChange(); });
     }
 
     oldCursorPos = fContext->GetCursor();
@@ -223,7 +223,7 @@ namespace textinput {
     if (!ColModR.fDisplay.IsEmpty()
         || ColModR.fDisplay.fPromptUpdate != Range::kNoPromptUpdate) {
       std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                    std::bind2nd(std::mem_fun(&Display::NotifyTextChange), ColModR.fDisplay));
+                    [ColModR](Display *D) { return D->NotifyTextChange(ColModR.fDisplay); });
     }
   }
 
@@ -244,8 +244,7 @@ namespace textinput {
     fNeedPromptRedraw = false;
     // Immediate refresh.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                  std::bind2nd(std::mem_fun(&Display::NotifyTextChange),
-                               R.fDisplay));
+                  [R](Display *D) { return D->NotifyTextChange(R.fDisplay); });
     // Empty range.
     R.fDisplay = Range::Empty();
 
@@ -264,8 +263,7 @@ namespace textinput {
     fNeedPromptRedraw = false;
     std::for_each(fContext->GetDisplays().begin(),
                   fContext->GetDisplays().end(),
-                  std::bind2nd(std::mem_fun(&Display::NotifyTextChange),
-                               Range::AllWithPrompt()));
+                  [](Display *D) { return D->NotifyTextChange(Range::AllWithPrompt()); });
   }
 
   void
@@ -288,10 +286,10 @@ namespace textinput {
     if (fActive) return;
     // Signal readers that we are about to read.
     std::for_each(fContext->GetReaders().begin(), fContext->GetReaders().end(),
-                  std::mem_fun(&Reader::GrabInputFocus));
+                  [](Reader *R) { return R->GrabInputFocus(); });
     // Signal displays that we are about to display.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                  std::mem_fun(&Display::Attach));
+                  [](Display *D) { return D->Attach(); });
     fActive = true;
   }
 
@@ -300,11 +298,11 @@ namespace textinput {
     // Signal readers that we are done reading.
     if (!fActive) return;
     std::for_each(fContext->GetReaders().begin(), fContext->GetReaders().end(),
-                  std::mem_fun(&Reader::ReleaseInputFocus));
+                  [](Reader *R) { return R->ReleaseInputFocus(); });
 
     // Signal displays that we are done displaying.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                  std::mem_fun(&Display::Detach));
+                  [](Display *D) { return D->Detach(); });
 
     fActive = false;
   }
@@ -326,7 +324,7 @@ namespace textinput {
   TextInput::HandleResize() {
     // Resize signal was emitted, tell the displays.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-             std::mem_fun(&Display::NotifyWindowChange));
+                  [](Display *D) { return D->NotifyWindowChange(); });
   }
 
   void

--- a/lib/UserInterface/textinput/TextInput.h
+++ b/lib/UserInterface/textinput/TextInput.h
@@ -89,7 +89,7 @@ namespace textinput {
     void AddHistoryLine(const char* line);
 
   private:
-    void EmitSignal(char c, EditorRange& r);
+    void HandleControl(char c, EditorRange& r);
     void ProcessNewInput(const InputData& in, EditorRange& r);
     void DisplayNewInput(EditorRange& r, size_t& oldCursorPos);
 


### PR DESCRIPTION
This pull request fixes most of #212, as well as includes a fix for a typo that I noticed. I say "most" because <kbd>Control</kbd>+<kbd>C</kbd> doesn't interrupt the interpreter, as it does in other programs do. Is this something that's worth pursing?