### PR TITLE
Add support for interrupting execution with ^C

### DIFF
--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -131,6 +131,8 @@ namespace cling {
       kExeUnkownFunction,
       ///\brief The Transaction had no module (probably an error in CodeGen).
       kExeNoModule,
+      ///\brief Execution was interrupted (recieved a SIGINT during execution).
+      kExeInterrupted,
 
       ///\brief Number of possible results.
       kNumExeResults

--- a/include/cling/Utils/Signal.h
+++ b/include/cling/Utils/Signal.h
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Saagar Jha <saagar@saagarjha.com>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef CLING_SIGNAL_H
+#define CLING_SIGNAL_H
+
+#include <csignal>
+#include <csetjmp>
+
+extern jmp_buf before_execution;
+
+void InterruptHandler();
+
+#endif // CLING_SIGNAL_H

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -31,6 +31,7 @@ add_cling_library(clingUtils OBJECT
   PlatformMac.cpp
   PlatformPosix.cpp
   PlatformWin.cpp
+  Signal.cpp
   SourceNormalization.cpp
   UTF8.cpp
   Validation.cpp

--- a/lib/Utils/Signal.cpp
+++ b/lib/Utils/Signal.cpp
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Saagar Jha <saagar@saagarjha.com>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include "cling/Utils/Signal.h"
+
+#include "llvm/Support/Signals.h"
+
+jmp_buf before_execution;
+
+void InterruptHandler() {
+  // LLVM automatically resets the handler after every call. Set it back to our
+  // handler for the next time we get a SIGINT.
+  llvm::sys::SetInterruptFunction(InterruptHandler);
+  longjmp(before_execution, 1);
+}

--- a/tools/driver/cling.cpp
+++ b/tools/driver/cling.cpp
@@ -10,6 +10,7 @@
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/MetaProcessor/MetaProcessor.h"
 #include "cling/UserInterface/UserInterface.h"
+#include "cling/Utils/Signal.h"
 
 #include "clang/Basic/LangOptions.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -57,6 +58,7 @@ int main( int argc, char **argv ) {
   llvm::llvm_shutdown_obj shutdownTrigger;
 
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  llvm::sys::SetInterruptFunction(InterruptHandler);
   llvm::PrettyStackTraceProgram X(argc, argv);
 
 #if defined(_WIN32) && defined(_MSC_VER)


### PR DESCRIPTION
I finished up <kbd>Control</kbd>+<kbd>C</kbd> support by interrupting execution whenever a `SIGINT` is received, as described by #243. I still can't get cling to build on my personal computer, so this pull request was tested on a Linux machine instead. Do let me know if there's anything I need to change!