### PR TITLE
Detection of attributes at function definition.

### DIFF
--- a/lib/Utils/SourceNormalization.cpp
+++ b/lib/Utils/SourceNormalization.cpp
@@ -375,11 +375,31 @@ size_t cling::utils::getWrapPoint(std::string& source,
       return std::string::npos;
     }
 
-    const tok::TokenKind kind = Tok.getKind();
     // Prior behavior was to return getFileOffset, which was only used as an
     // in a test against std::string::npos. By returning 0 we preserve prior
     // behavior to pass the test against std::string::npos and wrap everything
     const size_t offset = 0;
+
+    // Check, if a function with c++ attributes should be defined.
+    while (Tok.getKind() == tok::l_square) {
+      Lex.Lex(Tok);
+      // Check, if attribute starts with '[['
+      if (Tok.getKind() != tok::l_square) {
+        return offset;
+      }
+      // Check, if the second '[' is closing.
+      if (!Lex.CheckBalance(Tok)) {
+        return offset;
+      }
+      Lex.Lex(Tok);
+      // Check, if the first '[' is closing.
+      if (Tok.getKind() != tok::r_square) {
+        return offset;
+      }
+      Lex.Lex(Tok);
+    }
+
+    const tok::TokenKind kind = Tok.getKind();
 
     if (kind == tok::raw_identifier && !Tok.needsCleaning()) {
       StringRef keyword(Tok.getRawIdentifier());


### PR DESCRIPTION
Pull Request for Issue #239 

**Attention!** The pull request is not ready for merge. At the moment it should be used for discussion. If all points marked as done in section _Working_ , the request is ready for merge.

# Description
At the moment, it is not possible to define functions with c++ or gnu attributes without the `.rawInput`-mode. The problem is, that the metalexer can't detect attributes at the function definition.

# Features
Following kinds of function definition should work.

case 1 - one ore more c++ attributes:
``` C++
[[ noreturn ]] foo() { ... }
[[deprecated]] [[nodiscard]] int bar(){ … }
```

case 2 - one (maybe more) gnu attributes
``` C++
__attribute__((global)) void foo(){...}
```

case 3 - one (maybe more) attributes which are aliases of gnu attribute or c++ attribute
``` C++
#define __global__  __attribute__((global))

__global__ void foo(){...}
```

# Working
* [x] case 1
* [ ] case 2
* [ ] case 3

# Implementation Details
At case 1, the `MinimalPPLexer` can detect `[` and `]` as l_square and r_square. So, the check of c++ attributes is not hard. At case 2 and 3 the attributes will detect as `tok::raw_identifier`. Without semantic, it could be a little bit tricky to detect the attribute and other c++ constructs right.
