### PR TITLE
Fix detection of Visual Studio directories

### DIFF
--- a/lib/UserInterface/textinput/TerminalDisplayWin.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayWin.cpp
@@ -19,6 +19,12 @@
 
 #include <assert.h>
 
+#ifdef UNICODE
+#define filename L"CONOUT$"
+#else
+#define filename "CONOUT$"
+#endif
+
 namespace textinput {
   TerminalDisplayWin::TerminalDisplayWin():
     TerminalDisplay(false), fStartLine(0), fIsAttached(false),
@@ -31,7 +37,7 @@ namespace textinput {
     if (!isConsole) {
       // Prevent redirection from stealing our console handle,
       // simply open our own.
-      fOut = ::CreateFile("CONOUT$", GENERIC_READ | GENERIC_WRITE,
+      fOut = ::CreateFile(filename, GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
         FILE_ATTRIBUTE_NORMAL, NULL);
       ::GetConsoleMode(fOut, &fOldMode);
@@ -47,6 +53,8 @@ namespace textinput {
     fMyMode = fOldMode | ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT;
     HandleResizeEvent();
   }
+
+#undef filename
 
   TerminalDisplayWin::~TerminalDisplayWin() {
     if (fDefaultAttributes) {

--- a/lib/Utils/PlatformWin.cpp
+++ b/lib/Utils/PlatformWin.cpp
@@ -131,8 +131,10 @@ static bool readFullStringValue(HKEY hkey, const char *valueName,
       return llvm::convertWideToUTF8(WideValue, value);
     }
   }
-
-  ReportError(result, "RegQueryValueEx");
+  std::string prefix("RegQueryValueEx(");
+  prefix += valueName;
+  prefix += ")";
+  ReportError(result, prefix.c_str());
   return false;
 }
 
@@ -189,12 +191,12 @@ static bool getVSEnvironmentString(int VSVersion, std::string& Path,
 
 static bool getVisualStudioVer(int VSVersion, std::string& Path,
                                const char* Verbose) {
-  if (getVSRegistryString("VisualStudio", VSVersion, Path, Verbose))
-    return true;
-
-  if (getVSRegistryString("VCExpress", VSVersion, Path, Verbose))
-    return true;
-
+  if (VSVersion < 15) {
+    if (getVSRegistryString("VisualStudio", VSVersion, Path, Verbose))
+      return true;
+    if (getVSRegistryString("VCExpress", VSVersion, Path, Verbose))
+      return true;
+  }
   if (getVSEnvironmentString(VSVersion, Path, Verbose))
     return true;
 
@@ -283,6 +285,12 @@ bool GetSystemRegistryString(const char *keyPath, const char *valueName,
   bool returnValue = false;
   HKEY hKey = NULL;
 
+  std::string prefix("RegOpenKeyEx(");
+  prefix += keyPath;
+  prefix += "\\";
+  prefix += valueName;
+  prefix += ")";
+
   // If we have a $VERSION placeholder, do the highest-version search.
   if (const char *placeHolder = ::strstr(subKey, "$VERSION")) {
     char bestName[256];
@@ -347,7 +355,7 @@ bool GetSystemRegistryString(const char *keyPath, const char *valueName,
       }
       ::RegCloseKey(hTopKey);
     } else
-      ReportError(lResult, "RegOpenKeyEx");
+      ReportError(lResult, prefix.c_str());
   } else {
     // If subKey is empty, then valueName is subkey, and we retreive that
     if (subKey[0]==0) {
@@ -360,7 +368,7 @@ bool GetSystemRegistryString(const char *keyPath, const char *valueName,
       returnValue = readFullStringValue(hKey, valueName, outValue);
       ::RegCloseKey(hKey);
     } else
-      ReportError(lResult, "RegOpenKeyEx");
+      ReportError(lResult, prefix.c_str());
   }
   return returnValue;
 }
@@ -446,6 +454,7 @@ bool GetVisualStudioDirs(std::string& Path, std::string* WinSDK,
     return true;
   }
 
+#if (_MSC_VER < 1910)
   // Try for any other version we can get
   Msg = Verbose ? "highest" : nullptr;
   const int Versions[] = { 14, 12, 11, 10, 9, 8, 0 };
@@ -455,6 +464,8 @@ bool GetVisualStudioDirs(std::string& Path, std::string* WinSDK,
       return true;
     }
   }
+#endif
+
   return false;
 }
 


### PR DESCRIPTION
- Add the key name in the error messages, instead of simply RegQueryValueEx and RegOpenKeyEx
- Check for "VisualStudio" and/or "VCExpress" in the registry only if the Version is less than 15 (Visual Studio 2017 is not adding any entry in the registry anymore)
- Only check for Visual Studio Dirs with Visual Studio 14 or less (should we really try this at all? since in general we cannot mix different versions...)

This prevents flooding the users with many messages like:
RegOpenKeyEx: returned 2: The system cannot find the file specified.
RegQueryValueEx: returned 2: The system cannot find the file specified.

And apparently, only the Windows Kit 10 is needed (and not complete Visual Studio)...