### PR TITLE
[WIP^2] add asm and llvm print out

### DIFF
--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -1528,10 +1528,12 @@ namespace cling {
   Interpreter::executeTransaction(Transaction& T) {
     assert(!isInSyntaxOnlyMode() && "Running on what?");
     assert(T.getState() == Transaction::kCommitted && "Must be committed");
-
     const std::shared_ptr<llvm::Module>& M = T.getModule();
     if (!M)
       return Interpreter::kExeNoModule;
+
+    // This command appears to be dumping LLVM bytecode in a readable format.
+    M->dump();
 
     IncrementalExecutor::ExecutionResult ExeRes
        = IncrementalExecutor::kExeSuccess;


### PR DESCRIPTION
As discussed on the discourse chat with Axel ( https://root-forum.cern.ch/t/get-assembly-llvm-bytecode-or-clang-ast-output/30800 )

This PR is just a WIP to share some tiny progress made towards adding support for printing out assembly and LLVM bytecode through cling macros.

So far I am in the stage of getting familiar with the LLVM/clang/cling internal functions. 

It appears to be quite easy to get the LLVM bytecode by dumping the generated module.

The process to obtain human-readable assembly seems to be a bit harder (or I just don't know how to do it). So far I've basically copy-pasted code that I found in Julia's coda ( https://github.com/JuliaLang/julia/blob/6caabc9d8b0146ef0edf5749d890a270d6a3da7e/src/disasm.cpp#L617 )

Right now I am stuck at getting the ArrayRef that (I guess) should contain the assembled assemby. I also don't know the true meaning of `slice` in this context. 
BUT it already successfully prints a `.text` assembly begin, as well as the added comment :)

Any help or pointers appreciated! 