### PR TITLE
One-line change to fix clingkernel when installed as symlink (e.g. by homebrew)

### DIFF
--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -105,7 +105,7 @@ class ClingKernel(Kernel):
             raise RuntimeError('Cannot find cling in $PATH. No cling, no fun.')
 
         try:
-            whichCling = os.readlink(clingInPath)
+            whichCling = os.path.realpath(clingInPath)
             whichCling = os.path.join(os.path.dirname(clingInPath), whichCling)
         except OSError as e:
             #If cling is not a symlink try a regular file


### PR DESCRIPTION
Switch `os.readlink` to `os.path.realpath` to follow symlinks that link to a relative path.

On my mac, when I installed cling through homebrew, it is installed to `/usr/local/Cellar/cling/0.5_2/libexec/bin/cling`, and symlinked to `/usr/local/bin/cling` as `/usr/local/bin/cling -> ../Cellar/cling/0.5_2/bin/cling`.

For me, the previous code, `os.readlink(shutil.which('cling'))` was returning `../Cellar/cling/0.5_2/bin/cling`, which is in fact what the symlink points to, but doesn't help us find the kernel:
```python
>>> os.readlink(shutil.which('cling'))
'../Cellar/cling/0.5_2/bin/cling'
```
The new code correctly _follows_ the symlink, which is what we want:
```python
>>> os.path.realpath(shutil.which('cling'))
'/usr/local/Cellar/cling/0.5_2/libexec/bin/cling'
```