### PR TITLE
Refactor incremental CUDA PTX compiler

### DIFF
--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -72,6 +72,7 @@ namespace cling {
   class LookupHelper;
   class Value;
   class Transaction;
+  class IncrementalCUDADeviceCompiler;
 
   ///\brief Class that implements the interpreter-like behavior. It manages the
   /// incremental compilation.
@@ -206,6 +207,11 @@ namespace cling {
     ///\brief Information about the last stored states through .storeState
     ///
     mutable std::vector<ClangInternalState*> m_StoredStates;
+
+    ///\brief Cling's worker class implementing the compilation of CUDA device
+    /// code
+    ///
+    std::unique_ptr<IncrementalCUDADeviceCompiler> m_CUDACompiler;
 
     enum {
       kStdStringTransaction = 0, // Transaction known to contain std::string

--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -58,7 +58,8 @@ namespace cling {
     unsigned HasOutput : 1;
     unsigned Verbose : 1;
     unsigned CxxModules : 1;
-    unsigned CUDA : 1;
+    unsigned CUDAHost : 1;
+    unsigned CUDADevice : 1;
     /// \brief The output path of any C++ PCMs we're building on demand.
     /// Equal to ModuleCachePath in the HeaderSearchOptions.
     std::string CachePath;

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -450,10 +450,14 @@ namespace {
         // in include/c++/6.3.0/type_traits:344 that clang then rejects. The
         // specialization is protected by !if _GLIBCXX_USE_FLOAT128 (which is
         // unconditionally set in c++config.h) and #if !__STRICT_ANSI__. Tweak
-        // the latter by disabling GNUMode:
-        cling::errs()
-          << "Disabling gnu++: "
-             "clang has no __float128 support on this target!\n";
+        // the latter by disabling GNUMode.
+        // the nvptx backend doesn't support 128 bit float
+        // a error message is not necessary
+        if(!CompilerOpts.CUDADevice) {
+          cling::errs()
+            << "Disabling gnu++: "
+               "clang has no __float128 support on this target!\n";
+        }
         Opts.GNUMode = 0;
       }
 #endif //_GLIBCXX_USE_FLOAT128

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -1025,7 +1025,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // This argument starts the cling instance with the x86 target. Otherwise,
     // the first job in the joblist starts the cling instance with the nvptx
     // target.
-    if(COpts.CUDA)
+    if(COpts.CUDAHost)
       argvCompile.push_back("--cuda-host-only");
 
     // argv[0] already inserted, get the rest

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -74,6 +74,7 @@ add_cling_library(clingInterpreter OBJECT
   DeclExtractor.cpp
   DefinitionShadower.cpp
   DeclUnloader.cpp
+  DeviceKernelInliner.cpp
   DynamicLibraryManager.cpp
   DynamicLookup.cpp
   DynamicExprInfo.cpp

--- a/lib/Interpreter/DeviceKernelInliner.cpp
+++ b/lib/Interpreter/DeviceKernelInliner.cpp
@@ -1,0 +1,30 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Simeon Ehrig <s.ehrig@hzdr.de>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include "DeviceKernelInliner.h"
+
+#include <clang/AST/Attr.h>
+
+#include <llvm/Support/Casting.h>
+
+namespace cling {
+
+DeviceKernelInliner::DeviceKernelInliner(clang::Sema *S) : ASTTransformer(S) {}
+
+ASTTransformer::Result DeviceKernelInliner::Transform(clang::Decl *D) {
+  clang::FunctionDecl *F = llvm::dyn_cast<clang::FunctionDecl>(D);
+  if (F && F->hasAttr<clang::CUDADeviceAttr>()) {
+    if (!F->isInlineSpecified()) {
+      F->setInlineSpecified(true);
+    }
+  }
+  return Result(D, true);
+}
+
+} // namespace cling

--- a/lib/Interpreter/DeviceKernelInliner.cpp
+++ b/lib/Interpreter/DeviceKernelInliner.cpp
@@ -18,9 +18,8 @@ namespace cling {
 DeviceKernelInliner::DeviceKernelInliner(clang::Sema *S) : ASTTransformer(S) {}
 
 ASTTransformer::Result DeviceKernelInliner::Transform(clang::Decl *D) {
-  clang::FunctionDecl *F = llvm::dyn_cast<clang::FunctionDecl>(D);
-  if (F && F->hasAttr<clang::CUDADeviceAttr>()) {
-    if (!F->isInlineSpecified()) {
+  if (clang::FunctionDecl* F = llvm::dyn_cast<clang::FunctionDecl>(D)) {
+    if (F->hasAttr<clang::CUDADeviceAttr>()) {
       F->setInlineSpecified(true);
     }
   }

--- a/lib/Interpreter/DeviceKernelInliner.h
+++ b/lib/Interpreter/DeviceKernelInliner.h
@@ -7,8 +7,8 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-#ifndef DEVICEKERNELINLINER_H
-#define DEVICEKERNELINLINER_H
+#ifndef CLING_DEVICEKERNELINLINER_H
+#define CLING_DEVICEKERNELINLINER_H
 
 #include "ASTTransformer.h"
 
@@ -30,11 +30,11 @@ namespace cling
 class DeviceKernelInliner : public ASTTransformer
 {
 public:
-    DeviceKernelInliner ( clang::Sema* S );
+    DeviceKernelInliner(clang::Sema* S);
 
-    ASTTransformer::Result Transform ( clang::Decl * D ) override;
+    ASTTransformer::Result Transform(clang::Decl * D) override;
 };
 
 }
 
-#endif // DEVICEKERNELINLINER_H
+#endif // CLING_DEVICEKERNELINLINER_H

--- a/lib/Interpreter/DeviceKernelInliner.h
+++ b/lib/Interpreter/DeviceKernelInliner.h
@@ -24,12 +24,11 @@ namespace cling
 // a __global__ kernel uses a __device__ function, this design caused an error.
 // Instead of generating the PTX code of the __device__ kernel in the same file
 // as the __global__ kernel, there is only an external declaration of the
-// __device__ function. However, normal PTX code does not support an external
-// declaration of functions.
+// __device__ function. However, PTX does not support an external declaration of
+// functions.
 
 class DeviceKernelInliner : public ASTTransformer
 {
-
 public:
     DeviceKernelInliner ( clang::Sema* S );
 

--- a/lib/Interpreter/DeviceKernelInliner.h
+++ b/lib/Interpreter/DeviceKernelInliner.h
@@ -1,0 +1,41 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Simeon Ehrig <s.ehrig@hzdr.de>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef DEVICEKERNELINLINER_H
+#define DEVICEKERNELINLINER_H
+
+#include "ASTTransformer.h"
+
+
+namespace cling
+{
+
+// This ASTTransformer adds an inline attribute to any CUDA __device__ kernel
+// that does not have the attribute. Inlining solves a problem caused by
+// incremental compilation of PTX code. In a normal compiler, all definitions
+// of __global__ and __device__ kernels are in the same translation unit. In
+// the incremental compiler, each kernel has its own translation unit. In case
+// a __global__ kernel uses a __device__ function, this design caused an error.
+// Instead of generating the PTX code of the __device__ kernel in the same file
+// as the __global__ kernel, there is only an external declaration of the
+// __device__ function. However, normal PTX code does not support an external
+// declaration of functions.
+
+class DeviceKernelInliner : public ASTTransformer
+{
+
+public:
+    DeviceKernelInliner ( clang::Sema* S );
+
+    ASTTransformer::Result Transform ( clang::Decl * D ) override;
+};
+
+}
+
+#endif // DEVICEKERNELINLINER_H

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -72,6 +72,13 @@ namespace cling {
     argv.insert(argv.end(), m_CuArgs->additionalPtxOpt.begin(),
                 m_CuArgs->additionalPtxOpt.end());
 
+    // add included files to the cling ptx
+    for (const char* c : invocationOptions.CompilerOpts.Remaining) {
+      std::string s(c);
+      if (s.find("-include") == 0)
+        argv.push_back(s);
+    }
+
     std::vector<const char*> argvChar;
     argvChar.resize(argv.size() + 1);
 

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -234,7 +234,6 @@ namespace cling {
   }
 
   bool cling::IncrementalCUDADeviceCompiler::generatePTX() {
-
     std::error_code EC;
     llvm::raw_fd_ostream os(m_PTXFilePath, EC, llvm::sys::fs::F_None);
     if (EC) {

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -205,8 +205,10 @@ namespace cling {
     }
   }
 
-  bool IncrementalCUDADeviceCompiler::compileDeviceCode(
-      const llvm::StringRef input) {
+  // FIXME: add the same arguments as the cling::Interpreter class -> need some
+  // modifications in the cling::Transaction class to store information from the
+  // device compiler
+  bool IncrementalCUDADeviceCompiler::process(const llvm::StringRef input) {
     if (!m_Init) {
       llvm::errs()
           << "Error: Initializiation of CUDA Device Code Compiler failed\n";
@@ -216,14 +218,62 @@ namespace cling {
     Interpreter::CompilationResult CR = m_PTX_interp->process(input);
 
     if (CR == Interpreter::CompilationResult::kFailure) {
-      llvm::errs() << "failed at compile ptx code\n";
+      llvm::errs() << "IncrementalCUDADeviceCompiler::process()\n"
+                   << "failed at compile ptx code\n";
       return false;
     }
 
     // for example blocks which are not closed
-    if (CR == Interpreter::CompilationResult::kMoreInputExpected) return true;
+    if (CR == Interpreter::CompilationResult::kMoreInputExpected)
+      return true;
 
-    if (!generatePTX() || !generateFatbinary()) return false;
+    if (!generatePTX() || !generateFatbinary())
+      return false;
+
+    return true;
+  }
+
+  // FIXME: see process()
+  bool IncrementalCUDADeviceCompiler::declare(const llvm::StringRef input) {
+    if (!m_Init) {
+      llvm::errs()
+          << "Error: Initializiation of CUDA Device Code Compiler failed\n";
+      return false;
+    }
+
+    Interpreter::CompilationResult CR = m_PTX_interp->declare(input);
+
+    if (CR == Interpreter::CompilationResult::kFailure) {
+      llvm::errs() << "IncrementalCUDADeviceCompiler::declare()\n"
+                   << "failed at compile ptx code\n";
+      return false;
+    }
+
+    // for example blocks which are not closed
+    if (CR == Interpreter::CompilationResult::kMoreInputExpected)
+      return true;
+
+    if (!generatePTX() || !generateFatbinary())
+      return false;
+
+    return true;
+  }
+
+  // FIXME: see process()
+  bool IncrementalCUDADeviceCompiler::parse(const std::string& input) const {
+    if (!m_Init) {
+      llvm::errs()
+          << "Error: Initializiation of CUDA Device Code Compiler failed\n";
+      return false;
+    }
+
+    Interpreter::CompilationResult CR = m_PTX_interp->parse(input);
+
+    if (CR == Interpreter::CompilationResult::kFailure) {
+      llvm::errs() << "IncrementalCUDADeviceCompiler::parse()"
+                   << "failed at compile ptx code\n";
+      return false;
+    }
 
     return true;
   }

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -153,6 +153,13 @@ namespace cling {
     */
     std::vector<std::string> additionalPtxOpt;
 
+    // search for defines (-Dmacros=value) in the args and add them to the PTX
+    // compiler args
+    for (const char* arg : invocationOptions.CompilerOpts.Remaining) {
+      std::string s = arg;
+      if (s.compare(0, 2, "-D") == 0) additionalPtxOpt.push_back(s);
+    }
+
     m_CuArgs.reset(new IncrementalCUDADeviceCompiler::CUDACompilerArgs(
         cppStdVersion, optLevel, smVersion, ptxSmVersion, fatbinSmVersion,
         fatbinArch, invocationOptions.Verbose(), debug, additionalPtxOpt,

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.h
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.h
@@ -45,7 +45,6 @@ namespace cling {
     /// generation
     struct CUDACompilerArgs {
       const std::string cppStdVersion;
-      const std::string optLevel;
       ///\brief contains information about host architecture
       const llvm::Triple hostTriple;
       const uint32_t smVersion;
@@ -59,12 +58,11 @@ namespace cling {
       const std::vector<std::string> additionalPtxOpt;
 
       CUDACompilerArgs(const std::string cppStdVersion,
-                       const std::string optLevel,
                        const llvm::Triple hostTriple, const uint32_t smVersion,
                        const uint32_t fatbinFlags, const bool verbose,
                        const bool debug,
                        const std::vector<std::string> additionalPtxOpt)
-          : cppStdVersion(cppStdVersion), optLevel(optLevel),
+          : cppStdVersion(cppStdVersion),
             hostTriple(hostTriple), smVersion(smVersion),
             fatbinFlags(fatbinFlags), verbose(verbose), debug(debug),
             additionalPtxOpt(additionalPtxOpt) {}
@@ -98,7 +96,7 @@ namespace cling {
     /// paths.
     void addHeaderSearchPathFlags(
         std::vector<std::string>& argv,
-        const std::shared_ptr<clang::HeaderSearchOptions> headerSearchOptions);
+        const std::shared_ptr<clang::HeaderSearchOptions> &headerSearchOptions);
 
     ///\brief Compiles a PTX file from the current input. The PTX code is
     /// written to cling.ptx.
@@ -116,12 +114,10 @@ namespace cling {
     ///
     ///\param [in] langOpts - The LangOptions of the CompilerInstance.
     ///\param [in] invocationOptions - The invocationOptions of the interpreter.
-    ///\param [in] intprOptLevel - The optimization level of the interpreter.
     ///\param [in] debugInfo - The debugInfo of the CompilerInstance.
     ///\param [in] hostTriple - The llvm triple of the host system
     void setCuArgs(const clang::LangOptions& langOpts,
                    const cling::InvocationOptions& invocationOptions,
-                   const int intprOptLevel,
                    const clang::codegenoptions::DebugInfoKind debugInfo,
                    const llvm::Triple hostTriple);
 
@@ -146,7 +142,7 @@ namespace cling {
     ///
     ///\return std::unique_ptr< cling::Interpreter >&
     ///
-    std::unique_ptr<Interpreter>& getPTXInterpreter() { return m_PTX_interp; }
+    Interpreter *getPTXInterpreter() { return m_PTX_interp.get(); }
 
     ///\brief Generate an new fatbin file with the path in
     /// CudaGpuBinaryFileNames.
@@ -162,7 +158,7 @@ namespace cling {
     ///
     ///\returns true, if all stages of generating fatbin runs right and a new
     /// fatbin file is written.
-    bool process(const llvm::StringRef input);
+    bool process(const std::string& input);
 
     ///\brief Generate an new fatbin file with the path in
     /// CudaGpuBinaryFileNames from input line, which doesn't contain
@@ -176,7 +172,7 @@ namespace cling {
     ///
     ///\returns true, if all stages of generating fatbin runs right and a new
     /// fatbin file is written.
-    bool declare(const llvm::StringRef input);
+    bool declare(const std::string& input);
 
     ///\brief Parses input line, which doesn't contain statements. No code
     /// generation is done.

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.h
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.h
@@ -156,6 +156,12 @@ namespace cling {
         const cling::InvocationOptions& invocationOptions,
         const clang::CompilerInstance& CI);
 
+    ///\brief Returns a reference to the PTX interpreter
+    ///
+    ///\return std::unique_ptr< cling::Interpreter >&
+    ///
+    std::unique_ptr<Interpreter>& getPTXInterpreter() { return m_PTX_interp; }
+
     ///\brief Generate an new fatbin file with the path in
     /// CudaGpuBinaryFileNames.
     /// It will add the content of input, to the existing source code, which was

--- a/lib/Interpreter/IncrementalCUDADeviceCompiler.h
+++ b/lib/Interpreter/IncrementalCUDADeviceCompiler.h
@@ -150,15 +150,44 @@ namespace cling {
 
     ///\brief Generate an new fatbin file with the path in
     /// CudaGpuBinaryFileNames.
-    /// It will add the content of input, to the existing source code, which was
-    /// passed to compileDeviceCode, before.
+    ///
+    /// This interface helps to run everything that the device compiler can run.
+    /// Note that this should be used when there is no idea of what kind of
+    /// input is going to be processed. Otherwise if is known, for example
+    /// only header files are going to be processed it is much faster to run the
+    /// specific interface for doing that - in the particular case - declare().
     ///
     ///\param [in] input - The input directly from the UI. Attention, the string
     /// must not be wrapped or transformed.
     ///
-    ///\returns True, if all stages of generating fatbin runs right and a new
+    ///\returns true, if all stages of generating fatbin runs right and a new
     /// fatbin file is written.
-    bool compileDeviceCode(const llvm::StringRef input);
+    bool process(const llvm::StringRef input);
+
+    ///\brief Generate an new fatbin file with the path in
+    /// CudaGpuBinaryFileNames from input line, which doesn't contain
+    /// statements.
+    ///
+    /// The interface circumvents the most of the extra work necessary to
+    /// compile and run statements.
+    ///
+    /// @param[in] input - The input containing only declarations (aka
+    ///                    Top Level Declarations)
+    ///
+    ///\returns true, if all stages of generating fatbin runs right and a new
+    /// fatbin file is written.
+    bool declare(const llvm::StringRef input);
+
+    ///\brief Parses input line, which doesn't contain statements. No code
+    /// generation is done.
+    ///
+    /// Same as declare without codegening. Useful when a library is loaded and
+    /// the header files need to be imported.
+    ///
+    ///\param[in] input - The input containing the declarations.
+    ///
+    ///\returns true if parsing of the input was correct
+    bool parse(const std::string& input) const;
 
     ///\brief Print some information of the IncrementalCUDADeviceCompiler to
     /// llvm::outs().

--- a/lib/Interpreter/IncrementalParser.cpp
+++ b/lib/Interpreter/IncrementalParser.cpp
@@ -17,6 +17,7 @@
 #include "DeclCollector.h"
 #include "DeclExtractor.h"
 #include "DefinitionShadower.h"
+#include "DeviceKernelInliner.h"
 #include "DynamicLookup.h"
 #include "IncrementalCUDADeviceCompiler.h"
 #include "IncrementalExecutor.h"
@@ -950,6 +951,9 @@ namespace cling {
       if (!isCUDADevice)
         ASTTransformers.emplace_back(
             new NullDerefProtectionTransformer(m_Interpreter));
+      else
+        ASTTransformers.emplace_back(
+            new DeviceKernelInliner(TheSema));
     }
     ASTTransformers.emplace_back(new DefinitionShadower(*TheSema, *m_Interpreter));
 

--- a/lib/Interpreter/IncrementalParser.h
+++ b/lib/Interpreter/IncrementalParser.h
@@ -45,7 +45,6 @@ namespace cling {
   class Transaction;
   class TransactionPool;
   class ASTTransformer;
-  class IncrementalCUDADeviceCompiler;
 
   ///\brief Responsible for the incremental parsing and compilation of input.
   ///
@@ -96,10 +95,6 @@ namespace cling {
     ///\brief DiagnosticConsumer instance
     ///
     std::unique_ptr<clang::DiagnosticConsumer> m_DiagConsumer;
-
-    ///\brief Cling's worker class implementing the compilation of CUDA device code
-    ///
-    std::unique_ptr<IncrementalCUDADeviceCompiler> m_CUDACompiler;
 
     using ModuleFileExtensions =
         std::vector<std::shared_ptr<clang::ModuleFileExtension>>;

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -579,6 +579,9 @@ namespace cling {
                               E.Group == frontend::Angled);
       }
     }
+
+    if (m_CUDACompiler)
+      m_CUDACompiler->getPTXInterpreter()->AddIncludePaths(PathStr, Delm);
   }
 
   void Interpreter::AddIncludePath(llvm::StringRef PathsStr) {

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -409,9 +409,18 @@ namespace cling {
 
   Transaction* Interpreter::Initialize(bool NoRuntime, bool SyntaxOnly,
                               llvm::SmallVectorImpl<llvm::StringRef>& Globals) {
-    // initialization is done by the host interpreter
-    // the host interpreter runs the code itself and at the device compiler
-    // using the declare() function
+    // The Initialize() function is called twice in CUDA mode. The first time
+    // the host interpreter is initialized and the second time the device
+    // interpreter is initialized. Without this if statement, a redefinition
+    // error would occur because process(), declare(), and parse() are designed
+    // to process the code in the host and device interpreter when called by the
+    // host interpreter instance. This means that first the Initialize()
+    // function of the host interpreter is called and the initialization code is
+    // processed in the host and device interpreter. It then calls the
+    // Initialize() function of the device interpreter and throws an error
+    // because the code was already processed in the host Initialize() function.
+    //
+    // declare() is only used to generate a valid Transaction object
     if (m_Opts.CompilerOpts.CUDADevice) {
       Transaction* T;
       declare("", &T);

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -258,7 +258,7 @@ namespace cling {
       setupCallbacks(*this, parentInterp);
     }
 
-    if(m_Opts.CompilerOpts.CUDA){
+    if(m_Opts.CompilerOpts.CUDAHost){
        if(m_DyLibManager->loadLibrary("libcudart.so", true) ==
          cling::DynamicLibraryManager::LoadLibResult::kLoadLibNotFound){
            llvm::errs() << "Error: libcudart.so not found!\n" <<

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -100,7 +100,7 @@ static const char kNoStdInc[] = "-nostdinc";
 CompilerOptions::CompilerOptions(int argc, const char* const* argv)
     : Language(false), ResourceDir(false), SysRoot(false), NoBuiltinInc(false),
       NoCXXInc(false), StdVersion(false), StdLib(false), HasOutput(false),
-      Verbose(false), CxxModules(false), CUDA(false) {
+      Verbose(false), CxxModules(false), CUDAHost(false), CUDADevice(false) {
   if (argc && argv) {
     // Preserve what's already in Remaining, the user might want to push args
     // to clang while still using main's argc, argv
@@ -126,9 +126,11 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
       // case options::OPT_d_Flag:
       case options::OPT_E:
       case options::OPT_o: HasOutput = true; break;
-      case options::OPT_x: Language = true;
-                           CUDA = llvm::StringRef(arg->getValue()) == "cuda";
-                           break;
+      case options::OPT_x:
+        Language = true;
+        CUDAHost =
+            (CUDADevice) ? 0 : llvm::StringRef(arg->getValue()) == "cuda";
+        break;
       case options::OPT_resource_dir: ResourceDir = true; break;
       case options::OPT_isysroot: SysRoot = true; break;
       case options::OPT_std_EQ: StdVersion = true; break;
@@ -144,8 +146,14 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
       case options::OPT_fmodules_cache_path: CachePath = arg->getValue(); break;
       case options::OPT_cuda_path_EQ: CUDAPath = arg->getValue(); break;
       case options::OPT_cuda_gpu_arch_EQ: CUDAGpuArch = arg->getValue(); break;
-      case options::OPT_Xcuda_fatbinary: CUDAFatbinaryArgs.push_back(arg->getValue());
-                                         break;
+      case options::OPT_Xcuda_fatbinary:
+        CUDAFatbinaryArgs.push_back(arg->getValue());
+        break;
+      case options::OPT_cuda_device_only:
+        Language = true;
+        CUDADevice = true;
+        CUDAHost = false;
+        break;
 
       default:
         if (Inputs && arg->getOption().getKind() == Option::InputClass)
@@ -164,7 +172,8 @@ bool CompilerOptions::DefaultLanguage(const LangOptions* LangOpts) const {
   // Also don't set up the defaults when language is explicitly set; unless
   // the language was set to generate a PCH, in which case definitely do.
   if (Language)
-    return HasOutput || (LangOpts && LangOpts->CompilingPCH) || CUDA;
+    return HasOutput || (LangOpts && LangOpts->CompilingPCH) || CUDAHost ||
+           CUDADevice;
 
   return true;
 }

--- a/lib/Utils/SourceNormalization.cpp
+++ b/lib/Utils/SourceNormalization.cpp
@@ -375,6 +375,25 @@ size_t cling::utils::getWrapPoint(std::string& source,
       return std::string::npos;
     }
 
+    // detect the attribute (__global__, __device__ and __host__) of CUDA
+    // kernels at the beginning of a function definition
+    // FIXME: should replaced by a generic solution
+    if (LangOpts.CUDA) {
+      do {
+        if (Tok.getKind() == tok::raw_identifier) {
+          StringRef keyword(Tok.getRawIdentifier());
+          if (keyword.equals("__global__") || keyword.equals("__device__") ||
+              keyword.equals("__host__"))
+            // if attribute was found, skip the token and use the function
+            // detection later
+            Lex.Lex(Tok);
+          else
+            break;
+        } else
+          break;
+      } while (true);
+    }
+
     // Prior behavior was to return getFileOffset, which was only used as an
     // in a test against std::string::npos. By returning 0 we preserve prior
     // behavior to pass the test against std::string::npos and wrap everything

--- a/test/CUDADeviceCode/CUDADefineArg.C
+++ b/test/CUDADeviceCode/CUDADefineArg.C
@@ -1,12 +1,13 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// The Test checks whether a define argument (-DTEST=3) is passed to the PTX 
+// The Test checks whether a define argument (-DTEST=3) is passed to the PTX
 // compiler. If it works, it should not throw an error.
 // RUN: cat %s | %cling -DTEST=3 -x cuda -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime

--- a/test/CUDADeviceCode/CUDADefineArg.C
+++ b/test/CUDADeviceCode/CUDADefineArg.C
@@ -1,0 +1,40 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// The Test checks whether a define argument (-DTEST=3) is passed to the PTX 
+// compiler. If it works, it should not throw an error.
+// RUN: cat %s | %cling -DTEST=3 -x cuda -Xclang -verify 2>&1 | FileCheck %s
+// REQUIRES: cuda-runtime
+
+#include <iostream>
+
+// Check if cuda driver is available
+int version;
+cudaDriverGetVersion(&version)
+// CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+
+// Check if a CUDA compatible device (GPU) is available.
+int device_count = 0;
+cudaGetDeviceCount(&device_count)
+// CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+device_count > 0
+// CHECK: (bool) true
+
+TEST
+// CHECK: (int) 3
+
+.rawInput 1
+
+__global__ void g(){
+    int i = TEST;
+}
+
+.rawInput 0
+
+// expected-no-diagnostics
+.q

--- a/test/CUDADeviceCode/CUDAHostPrefix.C
+++ b/test/CUDADeviceCode/CUDAHostPrefix.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDAInclude.C
+++ b/test/CUDADeviceCode/CUDAInclude.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDAKernelArgument.C
+++ b/test/CUDADeviceCode/CUDAKernelArgument.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDAKernelTemplateComplex.C
+++ b/test/CUDADeviceCode/CUDAKernelTemplateComplex.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDAKernelTemplateSimple.C
+++ b/test/CUDADeviceCode/CUDAKernelTemplateSimple.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDARegression.C
+++ b/test/CUDADeviceCode/CUDARegression.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDARegression.C
+++ b/test/CUDADeviceCode/CUDARegression.C
@@ -1,0 +1,61 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// The test checks if the interface functions process(), declare() and parse()
+// of cling::Interpreter also work in the cuda mode.
+// RUN: cat %s | %cling -DTEST_PATH="\"%/p/\"" -x cuda -Xclang -verify 2>&1 | FileCheck %s
+// REQUIRES: cuda-runtime
+
+#include "cling/Interpreter/Interpreter.h"
+
+// if process() works, the general input also works
+gCling->process("cudaGetLastError()");
+//CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+
+// declare a cuda kernel with with a define
+// do not this in real code ;-)
+gCling->declare("#define FOO 42");
+gCling->declare("__global__ void g1(int * out){ *out = FOO;}");
+
+// allocate memory on CPU and GPU
+int *d1;
+int h1 = 0;
+cudaMalloc((void**)&d1, sizeof(int))
+//CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+
+// run kernel
+g1<<<1,1>>>(d1);
+cudaGetLastError()
+//CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+
+// check result
+cudaMemcpy(&h1, d1, sizeof(int), cudaMemcpyDeviceToHost)
+//CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+h1
+//CHECK: (int) 42
+
+// same test as declare()
+// reuse memory
+// FIXME: at the moment there is no check whether the device compiler generates
+// code or not
+// to fix the problem, cling needs a debug interface for the device compiler
+gCling->parse("__global__ void g2(int * out){ *out = 52;}");
+
+g2<<<1,1>>>(d1);
+cudaGetLastError()
+//CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+
+cudaMemcpy(&h1, d1, sizeof(int), cudaMemcpyDeviceToHost)
+//CHECK: (cudaError_t) (cudaError::cudaSuccess) : (unsigned int) 0
+h1
+//CHECK: (int) 52
+
+cudaFree(d1)
+
+// expected-no-diagnostics
+.q

--- a/test/CUDADeviceCode/CUDASharedMemory.C
+++ b/test/CUDADeviceCode/CUDASharedMemory.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDASimpleKernel.C
+++ b/test/CUDADeviceCode/CUDASimpleKernel.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/CUDAStreams.C
+++ b/test/CUDADeviceCode/CUDAStreams.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/CUDADeviceCode/include/foo.h
+++ b/test/CUDADeviceCode/include/foo.h
@@ -1,0 +1,8 @@
+#ifndef FOO_H
+#define FOO_H
+
+int foo() { return 3; }
+
+__global__ void bar() { int i = 4; }
+
+#endif

--- a/test/Driver/CUDAMode.C
+++ b/test/Driver/CUDAMode.C
@@ -1,5 +1,6 @@
 //------------------------------------------------------------------------------
 // CLING - the C++ LLVM-based InterpreterG :)
+// author: Simeon Ehrig <s.ehrig@hzdr.de>
 //
 // This file is dual-licensed: you can choose to license it under the University
 // of Illinois Open Source License or the GNU Lesser General Public License. See

--- a/test/Interfaces/invocationFlags.C
+++ b/test/Interfaces/invocationFlags.C
@@ -36,7 +36,9 @@ COpts.NoBuiltinInc
 // CHECK-NEXT: (unsigned int) 1
 COpts.NoCXXInc
 // CHECK-NEXT: (unsigned int) 0
-COpts.CUDA
+COpts.CUDAHost
+// CHECK-NEXT: (unsigned int) 0
+COpts.CUDADevice
 // CHECK-NEXT: (unsigned int) 0
 
 COpts.DefaultLanguage()
@@ -67,8 +69,10 @@ IOpts.CompilerOpts.NoBuiltinInc
 // CHECK-NEXT: (unsigned int) 0
 IOpts.CompilerOpts.NoCXXInc
 // CHECK-NEXT: (unsigned int) 1
-IOpts.CompilerOpts.CUDA
+IOpts.CompilerOpts.CUDAHost
 // CHECK-NEXT: (unsigned int) 1
+IOpts.CompilerOpts.CUDADevice
+// CHECK-NEXT: (unsigned int) 0
 
 // if the language is cuda, it should set automatically the c++ standard
 IOpts.CompilerOpts.DefaultLanguage()
@@ -79,6 +83,19 @@ IOpts.CompilerOpts.Remaining
 
 // Windows translates -nostdinc++ to -nostdinc++. Ignore that fact for the test.
 // CHECK-NEXT: {{.*}} { "progname", "-xcuda", "FileToExecuteA", "-isysroot", "APAth", {{.*}}, "-v", "FileToExecuteB" }
+
+// this flag allows to compile ptx code with the interpreter instance
+// CUDAHost and CUDADevice must not be true at the same time
+// if --cuda-device-only is set, it isn't important if -xcuda is set
+argv[10] = "--cuda-device-only";
+
+cling::InvocationOptions IOpts2(argc, argv);
+
+IOpts2.CompilerOpts.CUDAHost
+// CHECK-NEXT: (unsigned int) 0
+
+IOpts2.CompilerOpts.CUDADevice
+// CHECK-NEXT: (unsigned int) 1
 
 // expected-no-diagnostics
 .q

--- a/test/Interfaces/invocationFlags.C
+++ b/test/Interfaces/invocationFlags.C
@@ -86,7 +86,7 @@ IOpts.CompilerOpts.Remaining
 
 // this flag allows to compile ptx code with the interpreter instance
 // CUDAHost and CUDADevice must not be true at the same time
-// if --cuda-device-only is set, it isn't important if -xcuda is set
+// --cuda-device-only implies -xcuda
 argv[10] = "--cuda-device-only";
 
 cling::InvocationOptions IOpts2(argc, argv);

--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -217,7 +217,7 @@ def fetch_llvm(llvm_revision):
             exec_subprocess_call('git checkout %s' % LLVM_BRANCH, srcdir)
         else:
             exec_subprocess_call('git checkout cling-patches-r%s' % llvm_revision, srcdir)
-    
+
     def get_fresh_llvm():
         if LLVM_BRANCH:
             exec_subprocess_call('git clone --depth=10 --branch %s %s %s'
@@ -494,7 +494,7 @@ def compile(arg, build_libcpp):
 
     build = Build()
     cmake_config_flags = (srcdir + ' -DLLVM_BUILD_TOOLS=Off -DCMAKE_BUILD_TYPE={0} -DCMAKE_INSTALL_PREFIX={1} '
-                          .format(build.buildType, TMP_PREFIX) + ' -DLLVM_TARGETS_TO_BUILD=host ' +
+                          .format(build.buildType, TMP_PREFIX) + ' -DLLVM_TARGETS_TO_BUILD="host;NVPTX" ' +
                           EXTRA_CMAKE_FLAGS)
 
     libcxx = ''
@@ -634,7 +634,7 @@ def cleanup():
     global gInCleanup
     if gInCleanup:
         print('Failure in cleanup lead to recursion\n')
-        return 
+        return
 
     gInCleanup = True
     print('\n')
@@ -1885,7 +1885,7 @@ if args['check_requirements']:
                 install_line += pkg + ' '
         yes = {'yes', 'y', 'ye', ''}
         no = {'no', 'n'}
-        
+
         if install_line != '':
             choice = custom_input('''
     CPT will now attempt to update/install the requisite packages automatically.


### PR DESCRIPTION
# About

Two major modifications to cling are required to jiting CUDA code. On the one hand, the host side (x86 target) needs some modifications to understand the cuda host code, distinguish the [host and device](https://devblogs.nvidia.com/easy-introduction-cuda-c-and-c/) code, and embed the device code (PTX target) into the host code. On the other hand, a second jit compiler needed to compile the device code next to the host code.

# Current implementation

Currently the PTX jit compiler (cuda device code) is implemented in  [IncrementalCUDADeviceCompiler.h](https://github.com/SimeonEhrig/cling/blob/master/lib/Interpreter/IncrementalCUDADeviceCompiler.h) and [IncrementalCUDADeviceCompiler.cpp](https://github.com/SimeonEhrig/cling/blob/master/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp). The basic idea is to use file I/O and external tools via `llvm::sys::ExecuteAndWait`. For example, if we enter `N` statements, we compile the PTX code with:

```bash
clang++ -std=c++xx -Ox -S cling0.cu cling1.cu ... clingN.cu -o cling.ptx --cuda-gpu-arch=sm_xx -pthread --cuda-device-only
```
When we add a new statement, we execute the following command:

```bash
clang++ -std=c++xx -Ox -S cling0.cu cling1.cu ... clingN.cu clingN+1.cu -o cling.ptx --cuda-gpu-arch=sm_xx -pthread --cuda-device-only
```
There is also a necessary step to translate the PTX code to fatbin code. At the moment this step is not refactorized because it requires proprietary software and there is no API provided.

After compiling the fatbin code, the code is read and embedded by the cling.

## Problems

The current implementation has a lot of problems.
1. **Generating valid CUDA C++ code:** The PTX compiler cannot directly compile the source code entered by the user, because cling allows invalid syntax, e.g. function calls in global space. The handling of variables has a similar problem. Cling itself transform the code internally to valid C++ code. The transformation is performed in the AST-Tree. At the moment we use the ASTPrinter to generate C++ code from the AST. However, the ASTPrinter is designed to print error messages and not to generate valid C++ code. So there are many individual bugs in the printer.
2. **Performance:** At the moment there is no possibility to save any progress of the translation. So we have to compile the whole entire code plus the new statement for each input, which we do. So the compile time constantly increasing.
3. **Handling Cling passes:** Cling performs some internal transformations to provide new functions, e.g. the `NullDerefProtectionTransformer`, which protects the cling runtime from crashes caused by `nullptr` differentiation. Some transformations cause some problems on the device side and are not necessary.  
4. **File-I/O:** File I/O is slow, especially on HPC-Systems.
5. **Dependencies on external tools:** Sometime, especially on HPC systems, it is not easy to find all necessary tools. Integrating the tools at build time avoid some problems during runtime.

# Idea

The main idea is to use an integrated incremental compiler instance which can process the invalid source code from the prompt and generate PTX code incremental without having to compile the entire TU every time. I have already implemented a [prototype](https://github.com/SimeonEhrig/IncrementalPTXJIT), which implemented this idea. The prototype use some code from cling via `libcling.so` and use some code from the llvm and clang libraries. 

## Prototype
The prototype is divided into three parts. The first part is a simple prompt similar to the cling prompt for testing. The second part is a modified version of the cling interpreter instance, which I use as frontend. Details will follow. The changes are visible in the pull request. The last part is a PTX backend implement which I implemented with an unmodified llvm library.

### Frontend

Three modifications were necessary for the frontend.

1. Extending the [InvocationOptions.h](https://github.com/SimeonEhrig/cling/commit/3d0b2d166e48a4023255c2d2c9792101269c9cfa) to decide between the mode `CUDAHost` and `CUDADevice`. 
 * CUDAHost: normal cling functionality, e.g. jit and execute code with some extensions for CUDA host functionality 
 * CUDADevice: incremental compiling of CUDA device code to ptx without code execution.
2. Deactivation of some ASTTransformer that are not needed.
3. Added a new ASTTransformer to add the attribute `inline` to each `__device__` kernel. See this [commit](https://github.com/SimeonEhrig/cling/commit/a37e5596ec9da4680903cb7459612bbb37595f90). This is necessary because the PTX code generating functionality of the clang is not designed to handle many TUs. For example, if we have a `__device__` kernel [2] and a `__global__` kernel, the PTX code of the `__device__` kernel contains the definition of the `__device__` kernel in the PTX code. The PTX file generated for the `__global__` kernel contains the PTX code of the `__global__` kernel and an external declaration of the `__device__` function. But external declarations are forbidden in PTX code. So I needed a solution to copy the `__device__` kernel definition into the `__global__` kernel PTX file. 

[2] `__device__` kernel are only visible to `__global__` and other `__device__` kernels and cannot be called by the host.

In my prototype I use the functionality of the interpreter instance up to the generation of the llvm ir code (`llvm::Module`). Then I take the `llvm::Module` and pass it to a extra backend.  

### Backend

The backend is based on some llvm tutorials and is really generic. It takes a `llvm::Module` and translates it to PTX. It works really well, witht one exception I solved with the ASTTransformer. I already tested the generated PTX code of some basic functions with a hacked cling.  

# Questions

1. **PTX modification of the interpreter instance:** With the generaton of PTX code, there are three possible modes for the interpreter instance (C++, CUDA C++ host and PTX). Perhaps it make sense to use an inheritance hierarchy of the class `Interpreter` for clean code. On the other hand, I am not sure, if the class `Interpreter` has been designed for inheritance. Maybe it might require some refactoring work and make future development more difficult. Do you have any good reasons or ideas as to what I should do?
**Current solution:** `cling::Interpreter` has a pointer to a second `cling::Interpreter` instance. Some `if (CudeDevice)` statements within the class provide the correct functionality. 
2. **Inline ASTTransformer:** I think, I can replace my custom function pass with a solution of llvm https://github.com/root-project/cling/commit/d713ae033e49fae9d34f88607a254033b8c4e8c0. I still have to check it out. Maybe there is another, better solution to link the `__device__` kernel of one TU to a `__global__` kernel of another TU. Do you have any ideas? I have already checked the llvm module linker, but I dont't think the functionality is right for my problem.
**Current solution:** Use a self-written `ASTTransformer`.
3. **NVPTX backend without file I/O:** The NVPTX backend uses the function `llvm::MemoryBuffer::getFileOrSTDIN()` to load the fatbin code from file (see [source code](https://github.com/llvm/llvm-project/blob/9487963244e4c805cf0f5798d903bdb10012b59d/clang/lib/CodeGen/CGCUDANV.cpp#L501-L502) ). The path is set by the Cling. To get a full compiler stack without file I/O, we must avoid this step. Maybe we can use the virtual file system of clang or llvm. Or we try something with the STDIN. But I think that could cause a lot of problems. Otherwise, we have to change the clang source code so that it reads the code direct from a buffer.
**Current solution:** The clang code has been modified because `llvm::MemoryBuffer::getFileOrSTDIN()` does not support a virtual file system. 

# Tasks befor merge
These functions must be implemented so that the pull request is ready for merging.

- [x] Load fatbin code in NVPTX backend without file I/O (see Question 3.)
- [x] Add functionality at `cling::utils::getWrapPoint()` to handle the cuda function attributes `__global__`, `__device__` and `__host__`
- [ ] ~~fix bug with CUDA `__constant__` memory~~
- [x] fix bug with xeus-cling I/O

# Optional task
I moved the `__constant__` memory task to an optional task, because the solution more complicated, than I thought. `__constant__` is a frequently used feature, but is not required for the basic functionality of the CUDA extension.
- [ ] fix bug with CUDA `__constant__` memory

**Problem description:** https://github.com/SimeonEhrig/cling/issues/3
**Possible solution 1:** Use an ASTTransformer to remove the `__constant__` attribute from local variables. Is not easy to use because attributes are not stored in the AST. Attributes are stored in a side data structure (clang::Declarator). To check whether a statement has an attribute, we must perform the semantic analysis, which also checks properties of attributes which cause the `__constant__`-local-error. The built-in functions of clang for detecting and changing attributes should therefore not be usable. This means that we have to implement our own solution for detecting and changing attributes.     
**Possible solution 2:** Change the behavior of the ASTTransformer `DeclExtractor`. At the moment the `DeclExtractior` copies the declaration form the wrapper function to the global space and modify the local declaration a bit. If we could delete the local declaration completely, the error would not occur. But I don't know if the local declaration is necessary for any functionality.

# Overview of the most important changes

* modified `cling::Interpreter`
  * can be used as nvptx JIT
  * has a pointer to a second `cling::interpreter` instance -> host JIT has a device JIT
  * to avoid recursions and some errors in the device JIT, there are some `if(CudaDevice)` statements in the functions
* a new ASTTransformer that inline every cuda `__device__` kernel
  * is required because PTX is a plain assembler format without linking functionality
  * is needed for example, if we define a `__device__` kernel in transaction A and we want to use the `__device__` kernel in a `__global__` kernel of transaction B -> then we have to copy to whole definition of the `__device__` kernel into the PTX file of transaction B
* PTX and fatbinary are generated entirely in-memory
  * for PTX see modifications at `cling::Interpreter`
  * for the fatbinary code we need a modification at the `Clang` code, because, the Clang codeGen read the code via a function from a file that does not support a virtual file system
* CPT tool builds the nvptx beside the host target
  * avoid a lot of `#ifdef` guards
  * build is completly target independent
  * if the functionality is not used at runtime, it is also completly target independent
* Add the detection of CUDA attributes `__global__`, `__device__` and `__host__` to `SourceNormalization`
  * a general, intelligent approach would be better