### PR TITLE
Allowing clang to be built from an external repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,10 +463,17 @@ elseif(ROOT_CLASSIC)
     )
 else()
   # and this when building Cling standalone:
-  include_directories(BEFORE
-    ${CMAKE_CURRENT_BINARY_DIR}/../clang/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../clang/include
-    )
+  if (DEFINED LLVM_EXTERNAL_CLANG_SOURCE_DIR)
+     include_directories(BEFORE
+       ${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include
+       ${CMAKE_CURRENT_BINARY_DIR}/../clang/include
+       )
+  else()
+    include_directories(BEFORE
+      ${CMAKE_CURRENT_BINARY_DIR}/../clang/include
+      ${CMAKE_CURRENT_SOURCE_DIR}/../clang/include
+      )
+  endif()
 endif()
 
 include_directories(BEFORE


### PR DESCRIPTION
Useful for packaging Cling with spack, intended to be used with this integration of the ROOT cling-patches onto llvm-project's repository.

New location of the cling-patches, integrated with llvm-project and based off of llvm@5.0.2:

https://github.com/rblake-llnl/llvm-project/tree/cling-patches/clang

Old location of the clang cling-patches, standalone

http://root.cern.ch/git/clang.git , branch cling-patches.

I also have a version of llvm-project that can be used to build cling with spack standalone. This links to the github project using git submodules.

https://github.com/rblake-llnl/llvm-project/tree/full-cling-build/
