### PR TITLE
Include windows.h in DynamicLibraryManagerSymbol.cpp 

### DIFF
--- a/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -36,6 +36,7 @@
 #endif // __APPLE__
 
 #ifdef LLVM_ON_WIN32
+#include <windows.h>
 #include <libloaderapi.h> // For GetModuleFileNameA
 #include <memoryapi.h> // For VirtualQuery
 #endif


### PR DESCRIPTION
This fixes #352 (`fatal error C1189: #error:  "No Target Architecture"`).

The reason for the bug is that `libloaderapi.h` and `memoryapi.h` are not supposed to be included directly apparently, and it is checked that the right platform macro is defined, while it is only defined in windows.h.