### PR TITLE
Setup Github Actions CI for Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: Cling CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+
+        include:
+          - name: ubuntu-16.04-gcc
+            os: ubuntu-16.04
+            compiler: gcc
+
+          - name: ubuntu-16.04-clang
+            os: ubuntu-16.04
+            compiler: clang
+
+          - name: ubuntu-18.04-gcc
+            os: ubuntu-18.04
+            compiler: gcc
+
+          - name: ubuntu-18.04-clang
+            os: ubuntu-18.04
+            compiler: clang
+
+          - name: ubuntu-20.04-gcc-compile
+            os: ubuntu-20.04
+            compiler: gcc
+
+          - name: ubuntu-20.04-clang-compile
+            os: ubuntu-20.04
+            compiler: clang
+
+          - name: macos-10.15-xcode-11.2.1-fromtar
+            os: macOS-10.15
+            compiler: clang
+            xcode-version: "11.2.1"
+
+          - name: macos-10.15-gcc-9-compile
+            os: macOS-10.15
+            compiler: gcc
+            version: "9"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup compiler on Linux
+      run: |
+        sudo apt-get update
+        if [ "${{ matrix.compiler }}" = "gcc" ]; then
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+        else
+          sudo apt-get install -y clang
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+        fi
+      if: runner.os == 'Linux'
+      shell: bash
+    - name: Setup compiler on OS X
+      run: |
+        curl -LO https://raw.githubusercontent.com/GiovanniBussi/macports-ci/master/macports-ci; source ./macports-ci install
+        if [ "${{ matrix.compiler }}" = "gcc" ]; then
+          brew install gcc@${{ matrix.version }}
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+        else
+          sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode-version }}.app
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+        fi
+      if: runner.os == 'macOS'
+    - name: Display compiler version
+      run: $CC --version
+    - name: Execute cpt
+      run: |
+        if [[ "${{ matrix.compiler }}" = "gcc" && "${{ matrix.version }}" = "7" ]]; then
+          export CLING_BUILD_FLAGS="-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON"
+          if [ "${{ matrix.os }}" != "macOS-11.0" ] | [ "${{ matrix.os }}" != "macOS-10.15" ]; then
+            export CLING_BUILD_FLAGS="$CLING_BUILD_FLAGS -DCXX_EXTENSIONS=OFF"
+          fi
+        fi
+        export CLING_BUILD_FLAGS="$CLING_BUILD_FLAGS -DCLANG_ENABLE_ARCMT=OFF -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DLLVM_ENABLE_WARNINGS=OFF -DCLING_ENABLE_WARNINGS=ON"
+        if [[ ${{ matrix.name }} == *"compile"* ]]; then
+          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$GITHUB_REPOSITORY --cling-branch=${{ github.head_ref }}
+        elif [[ ${{ matrix.name }} == *"fromtar"* ]]; then
+          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$GITHUB_REPOSITORY --cling-branch=${{ github.head_ref }} --with-binary-llvm --with-llvm-tar
+        else
+          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$GITHUB_REPOSITORY --cling-branch=${{ github.head_ref }} --with-binary-llvm
+        fi
+      working-directory: tools/packaging/

--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -368,10 +368,10 @@ def fetch_cling(arg):
 
     def get_fresh_cling():
         if CLING_BRANCH:
-            exec_subprocess_call('git clone --depth=10 --branch %s %s'
+            exec_subprocess_call('git clone --depth=10 --branch %s %s cling'
                                  % (CLING_BRANCH, CLING_GIT_URL), os.path.join(dir, 'tools'))
         else:
-            exec_subprocess_call('git clone %s' % CLING_GIT_URL, os.path.join(dir, 'tools'))
+            exec_subprocess_call('git clone %s cling' % CLING_GIT_URL, os.path.join(dir, 'tools'))
 
         # if arg == 'last-stable':
         #    checkout_branch = exec_subprocess_check_output('git describe --match v* --abbrev=0 --tags | head -n 1',


### PR DESCRIPTION
We might want to move from Travis and Appveyor to using Github Actions for CI because Github Actions is more robust and provides a lot of advantages such as more concurrent builds, longer timeouts, individually examinable steps, etc. Also, we would be able to have CI for Windows, Linux and macOS in the same infrastructure since Github Actions supports all 3.
There are noticeably more builds in the presented Github Actions CI than the Travis CI because we are able to test Cling builds both from an LLVM binary as well as with compiling LLVM from source.

We will try and integrate Windows CI into Github Actions in a different PR because Windows builds (using cpt) seem to be broken currently and might need some additional effort to fix.

I found one downside of using Github Actions -  

- We cannot include macOS tests with XCode 9.3 (that we are currently testing in Travis), because Github Actions does not provide it. (We would need a self hosted runner to test this)

We do intend to remove travis at a later date if we integrate Github Actions CI, but we cannot yet since we would have to first integrate Deployment and Nightly Releases that are currently handled by Travis into our Github Actions. (@ax3l I remember you mentioned something about working on Continuous Deployments for Cling some time ago. Was there any progress on that? Otherwise I can try and get that done)

Something else that we need to look into wrt CI, is a way to test Cling's CUDA codegen as a part of CI.