### PR TITLE
Fix pip installation of packages via cpt and add Python 2 test to Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,39 +20,58 @@ jobs:
           - name: ubuntu-16.04-gcc
             os: ubuntu-16.04
             compiler: gcc
+            python-version: 3.8
 
           - name: ubuntu-16.04-clang
             os: ubuntu-16.04
             compiler: clang
+            python-version: 3.8
 
           - name: ubuntu-18.04-gcc
             os: ubuntu-18.04
             compiler: gcc
+            python-version: 3.8
 
           - name: ubuntu-18.04-clang
             os: ubuntu-18.04
             compiler: clang
+            python-version: 3.8
 
           - name: ubuntu-20.04-gcc-compile
             os: ubuntu-20.04
             compiler: gcc
+            python-version: 3.8
+
+          - name: ubuntu-20.04-gcc-compile-py2
+            os: ubuntu-20.04
+            compiler: gcc
+            python-version: 2.7
 
           - name: ubuntu-20.04-clang-compile
             os: ubuntu-20.04
             compiler: clang
+            python-version: 3.8
 
           - name: macos-10.15-xcode-11.2.1-fromtar
             os: macOS-10.15
             compiler: clang
             xcode-version: "11.2.1"
+            python-version: 3.8
 
           - name: macos-10.15-gcc-9-compile
             os: macOS-10.15
             compiler: gcc
             version: "9"
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Display Python version
+      run: python -V
     - name: Setup compiler on Linux
       run: |
         sudo apt-get update
@@ -96,10 +115,10 @@ jobs:
         fi
         export CLING_BUILD_FLAGS="$CLING_BUILD_FLAGS -DCLANG_ENABLE_ARCMT=OFF -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DLLVM_ENABLE_WARNINGS=OFF -DCLING_ENABLE_WARNINGS=ON"
         if [[ ${{ matrix.name }} == *"compile"* ]]; then
-          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }}
+          python cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }}
         elif [[ ${{ matrix.name }} == *"fromtar"* ]]; then
-          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm --with-llvm-tar
+          python cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm --with-llvm-tar
         else
-          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm
+          python cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm
         fi
       working-directory: tools/packaging/

--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -132,10 +132,7 @@ def box_draw(msg):
 
 
 def pip_install(package):
-    # Needs brew install python. We should only install if we need the
-    # functionality
-    import pip
-    pip.main(['install', '--ignore-installed', '--prefix', os.path.join(workdir, 'pip'), '--upgrade', package])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
 
 
 def wget(url, out_dir, rename_file=None, retries=3):
@@ -841,20 +838,6 @@ def check_ubuntu(pkg):
         else:
             print(pkg.ljust(20) + '[OK]'.ljust(30))
             return True
-    elif pkg == "python-pip":
-        if exec_subprocess_check_output('pip --version', workdir) != '':
-            print(pkg.ljust(20) + '[OK]'.ljust(30))
-            return True
-        else:
-            print(pkg.ljust(20) + '[NOT INSTALLED]'.ljust(30))
-            return False
-    elif pkg == "python3-pip":
-        if exec_subprocess_check_output('pip --version', workdir) != '':
-            print(pkg.ljust(20) + '[OK]'.ljust(30))
-            return True
-        else:
-            print(pkg.ljust(20) + '[NOT INSTALLED]'.ljust(30))
-            return False
     elif pkg == "subversion":
         if exec_subprocess_check_output('which svn', workdir) != '':
             print(pkg.ljust(20) + '[OK]'.ljust(30))
@@ -1668,13 +1651,6 @@ def check_mac(pkg):
             # Python 3.x
             print(pkg.ljust(20) + '[SUPPORTED]'.ljust(30))
             return True
-    elif pkg == "python-pip":
-        if exec_subprocess_check_output('pip --version', workdir) != '':
-            print(pkg.ljust(20) + '[OK]'.ljust(30))
-            return True
-        else:
-            print(pkg.ljust(20) + '[NOT INSTALLED]'.ljust(30))
-            return False
     elif pkg == "svn":
         if exec_subprocess_check_output('which svn', workdir) != '':
             print(pkg.ljust(20) + '[OK]'.ljust(30))
@@ -1957,23 +1933,10 @@ elif OS == 'Linux':
     except:
         yes = {'yes', 'y', 'ye', ''}
         choice = custom_input('''
-            CPT will now attempt to install the distro (and pip) package automatically.
+            CPT will now attempt to install the distro package automatically.
             Do you want to continue? [yes/no]: ''', args['y']).lower()
         if choice in yes:
-            if sys.version_info[0] == 3:
-                pipver = 'python3-pip'
-            else:
-                pipver = 'python2-pip'
-            if check_ubuntu(pipver) is False:
-                subprocess.Popen(['sudo apt-get install {0}'.format(pipver)],
-                                shell=True,
-                                stdin=subprocess.PIPE,
-                                stdout=None,
-                                stderr=subprocess.STDOUT).communicate('yes'.encode('utf-8'))
-            if sys.version_info[0] == 3:
-                subprocess.call("sudo pip3 install distro", shell=True)
-            else:
-                subprocess.call("sudo pip install distro", shell=True)
+            pip_install("distro")
             import distro
         else:
             print('Install/update the distro package from pip')


### PR DESCRIPTION
I think we should (atleast internally) formalize which Python versions cpt should support. 

We could do either of - 
1. Follow official Python release end of lifes, and only support Python 3.6 and above (and formally stop supporting Python versions as they reach their end of life). We should also probably add tests for the Python versions cpt officially supports to the new Github Actions CI.
2. Do not declare any supported Python versions on the README, but expect users to have atleast >= Python 2.7.9 and >= Python 3.4. This ensures that the Python version on the user's system comes with pip installed and makes it easier for cpt to install packages using pip. 

This PR addresses the latter and adds a Python 2.7 test to Github Actions CI.