### PR TITLE
fix DynamicLibraryManager::loadLibrary if the parameter resolve is `false`

### DIFF
--- a/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/lib/Interpreter/DynamicLibraryManager.cpp
@@ -356,12 +356,17 @@ namespace cling {
     }
 
     std::string lResolved;
-    const std::string& canonicalLoadedLib = resolved ? libStem.str() : lResolved;
     if (!resolved) {
       lResolved = lookupLibrary(libStem);
       if (lResolved.empty())
         return kLoadLibNotFound;
     }
+
+    // For reasons that are not clear, canonicalLoadedLib is a copy of lResolved and not 
+    // a reference if resolved is false.
+    // Therefore the type of canonicalLoadedLib const std::string and not a reference 
+    // to make it clear.
+    const std::string canonicalLoadedLib = resolved ? libStem.str() : lResolved;
 
     if (m_LoadedLibraries.find(canonicalLoadedLib) != m_LoadedLibraries.end())
       return kLoadLibAlreadyLoaded;


### PR DESCRIPTION
The const reference of lResolved in the statement `const std::string& canonicalLoadedLib = resolved ? libStem.str() : lResolved;` is a copy for unexplained reason

It also fixes the bug, that the `libcudart.so` is not correctly load at start up in CUDA mode.