### PR TITLE
Fixed undefined cmakeDir error mentioned in issue #426

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -1342,7 +1342,7 @@ def get_win_dep():
     tmp_bin_dir = os.path.join(TMP_PREFIX, 'bin')
     zip.extractall(tmp_bin_dir)
     print('Remove file: ' + os.path.join(TMP_PREFIX, 'cmake-3.6.2.zip'))
-
+    cmakeDir = TMP_PREFIX + "\\bin\\cmake"
     if is_os_64bit():
         os.rename(os.path.join(tmp_bin_dir, 'cmake-3.6.2-win64-x64'), cmakeDir)
     else:


### PR DESCRIPTION
Added cmakeDir for windows building of cling, this removed the error mentioned in #426, although the undefined llvm_flags issue is still there. This is interesting since it seems like this same llvm_flags issue happens for both Windows and Ubuntu, and possibly on other platforms. 