### PR TITLE
Do not register LLVMSupport as a library when it should be a component

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -9,9 +9,9 @@
 # Keep symbols for JIT resolution
 set(LLVM_NO_DEAD_STRIP 1)
 
+  set(LLVM_LINK_COMPONENTS support)
 if(BUILD_SHARED_LIBS)
   set(LIBS
-    LLVMSupport
 
     clangFrontendTool
 
@@ -25,8 +25,6 @@ if(BUILD_SHARED_LIBS)
   )
 else()
   set(LIBS
-    LLVMSupport
-
     clangASTMatchers
     clangFrontendTool
 


### PR DESCRIPTION
LLVM component must be registered as LLVM_LINK_COMPONENTS to be compatible with LLVM Dylib. Otherwise they are loaded twice in the final binary, once through LLVM Dylmib and once through individual component, and this results in some options being registered twice.

Fix #440