### PR TITLE
Update debian/compat to version 13

### DIFF
--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -1048,7 +1048,7 @@ share/* /usr/share
 
     print('Create file: ' + os.path.join(prefix, 'debian', 'compat'))
     f = open(os.path.join(prefix, 'debian', 'compat'), 'w')
-    f.write("9")
+    f.write("13")
     f.close()
 
     print('Create file: ' + os.path.join(prefix, 'debian', 'control'))


### PR DESCRIPTION
Compat version 13 is currently the recommended one.

An important change introduced in 10 was change of default to target parallel builds

https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/debhelper.pod#compatibility-levels