### PR TITLE
Fix diagnostic failure if an object return different types for begin() and end()

### DIFF
--- a/include/cling/Interpreter/RuntimePrintValue.h
+++ b/include/cling/Interpreter/RuntimePrintValue.h
@@ -200,7 +200,8 @@ namespace cling {
         typename std::enable_if<
             std::is_reference<decltype(*std::begin(*obj))>::value>::type* = 0)
         -> decltype(std::end(*obj), std::string()) {
-      auto iter = obj->begin(), iterEnd = obj->end();
+      auto iter = obj->begin();
+      auto iterEnd = obj->end();
       if (iter == iterEnd) return valuePrinterInternal::kEmptyCollection;
 
       const void* M = TypeTest::isMap(obj);
@@ -221,7 +222,8 @@ namespace cling {
         typename std::enable_if<
             !std::is_reference<decltype(*(obj->begin()))>::value>::type* = 0)
         -> decltype(++(obj->begin()), obj->end(), std::string()) {
-      auto iter = obj->begin(), iterEnd = obj->end();
+      auto iter = obj->begin();
+      auto iterEnd = obj->end();
       if (iter == iterEnd) return valuePrinterInternal::kEmptyCollection;
 
       std::string str("{ ");


### PR DESCRIPTION
Fix compilation error when `obj->begin()` and `obj->end()` return different type.

This case is uncommon, but used sometimes. E.g, unbounded [`std::ranges::iota_view`](https://en.cppreference.com/w/cpp/ranges/iota_view)