### PR TITLE
Fix CMake build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,10 @@ Our nightly binary snapshots can be found
 ### Building from Source
 
 ```sh
-git clone https://github.com/root-project/llvm-project.git
-cd llvm-project
-git checkout cling-latest
-cd ../
+git clone https://github.com/root-project/llvm-project.git -b cling-latest
 git clone <cling>
-mkdir cling-build && cd cling-build
-cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;nvptx" ../llvm-project/llvm
+cmake -Bcling-build -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" llvm-project/llvm
+cmake --build cling-build
 ```
 
 Usage


### PR DESCRIPTION
This is a very simple PR to improve the CMake build instructions. The existing ones are a bit too convoluted and can be simplified a lot, plus there is an issue mentioned at #515 about the `NVPTX` using the wrong name, which leads to a misleading error. (The first issue mentioned there about the build type only shows when you configure CMake with a non-multi-config generator, so I've left that one alone for the time being).

I hope this helps!