### PR TITLE
Remove references to Python 2 in preparation for the release of Root 6.32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX} )
 
   if(LLVM_INCLUDE_TESTS)
-    set(Python_ADDITIONAL_VERSIONS 2.7)
+    set(Python_ADDITIONAL_VERSIONS 3)
     include(FindPythonInterp)
     if(NOT PYTHONINTERP_FOUND)
       message(FATAL_ERROR
@@ -116,8 +116,8 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
     endif()
 
-    if( ${PYTHON_VERSION_STRING} VERSION_LESS 2.7 )
-      message(FATAL_ERROR "Python 2.7 or newer is required")
+    if( ${PYTHON_VERSION_STRING} VERSION_LESS 3 )
+      message(FATAL_ERROR "Python 3 or newer is required")
     endif()
 
     # Check prebuilt llvm/utils.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import, division, print_function
 import sys, os
 from datetime import date
 

--- a/docs/tools/in2pod.py
+++ b/docs/tools/in2pod.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # A tool to parse cling.pod.in and generate cling.pod dynamically
 
-from __future__ import print_function
 import subprocess
 import sys
 import os

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -13,13 +13,7 @@ from lit.llvm import llvm_config
 
 # Configuration file for the 'lit' test runner.
 
-if sys.version_info < (3, 0):
-    # Python 2.x
-    from urllib2 import urlopen
-    input = raw_input
-else:
-    # Python 3.x
-    from urllib.request import urlopen
+from urllib.request import urlopen
 
 IsWindows = platform.system() == 'Windows'
 

--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------
 # CLING - the C++ LLVM-based InterpreterG :)
 # author:  Min RK
@@ -15,7 +15,6 @@ Cling Kernel for Jupyter
 Talks to Cling via ctypes
 """
 
-from __future__ import print_function
 
 __version__ = '0.0.3'
 

--- a/tools/Jupyter/kernel/scripts/jupyter-cling-kernel
+++ b/tools/Jupyter/kernel/scripts/jupyter-cling-kernel
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from clingkernel import main
 main()

--- a/tools/Jupyter/kernel/setup.py
+++ b/tools/Jupyter/kernel/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 #------------------------------------------------------------------------------
@@ -11,7 +11,6 @@
 # LICENSE.TXT for details.
 #------------------------------------------------------------------------------
 
-from __future__ import print_function
 
 # the name of the project
 name = 'clingkernel'
@@ -23,12 +22,11 @@ name = 'clingkernel'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+if v[0] >= 3 and v[:2] < (3,3):
+    error = "ERROR: %s requires Python version 3.3 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
-PY3 = (sys.version_info[0] >= 3)
 
 #-----------------------------------------------------------------------------
 # get on with it

--- a/tools/packaging/cpt.py
+++ b/tools/packaging/cpt.py
@@ -21,10 +21,6 @@
 
 
 import sys
-
-if sys.version_info < (3, 0):
-    raise Exception("cpt needs Python 3")
-
 import argparse
 import copy
 import os
@@ -100,7 +96,7 @@ def travis_fold_end(tag):
 
 def box_draw_header():
     msg = 'cling (' + platform.machine() + ')' \
-    + formatdate(time.time(), tzinfo()) 
+    + formatdate(time.time(), tzinfo())
     spaces_no = 80 - len(msg) - 4
     spacer = ' ' * spaces_no
     msg = 'cling (' + platform.machine() + ')' \
@@ -1842,7 +1838,7 @@ def make_dmg(CPT_SRC_DIR):
 
 parser = argparse.ArgumentParser(description='Cling Packaging Tool')
 parser.add_argument('--last-stable-build', help='Build the last stable snapshot in one of these formats: tar | deb | nsis | rpm | dmg | pkg')
-parser.add_argument('--current-dev-build', 
+parser.add_argument('--current-dev-build',
                     help=('--current-dev:<tar | deb | nsis | rpm | dmg | pkg> will build the latest development snapshot in the given format'
                           + '\n--current-dev:branch:<branch> will build <branch> on llvm, clang, and cling'
                           + '\n--current-dev:branches:<a,b,c> will build branch <a> on llvm, <b> on clang, and <c> on cling'))


### PR DESCRIPTION
Support for Python 2 will be dropped in Root version 6.32. Please see https://github.com/root-project/root/issues/13861. The purpose of this PR is to make updating Root easier.