### PR TITLE
Minor build guide tweaks [dup,closed]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ git clone https://github.com/root-project/llvm-project.git
 cd llvm-project
 git checkout cling-latest
 cd ../
-git clone <cling>
+git clone https://github.com/root-project/cling.git
 mkdir cling-build && cd cling-build
-cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;nvptx" ../llvm-project/llvm
+cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" ../llvm-project/llvm # if failed, try `nvptx` instead
+cmake --build . --target cling
 ```
 
 Usage


### PR DESCRIPTION
I'm not sure if it's just me, but after spending an entire day building Cling, CMake kept notifying me that the target `nvptx` was not found.  It's really confused someone who has little experience with CMake like me. Then I searched the LLVM repository and found that the target name was capitalized as `NVPTX`. CMake is clearly case-sensitive. If it's not just me, then there's an issue with the build guide. I simply changed `nvptx` to `NVPTX` and added the comment `# if failed, try nvptx instead` after the command just in case.