### PR TITLE
[skip-CI][cling] Refine build and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Our nightly binary snapshots are currently unavailable.
 
 ### Building from Source
 
+#### If Clang and LLVM in cling-latest version are Already Installed
+
+```bash
+git clone https://github.com/root-project/cling.git
+mkdir cling-build && cd cling-build
+cmake ../cling
+cmake --build .
+```
+
+#### Build Cling Along with LLVM
+If Clang and LLVM are not installed, you can build them together with Cling:
+
 ```bash
 git clone https://github.com/root-project/llvm-project.git
 cd llvm-project
@@ -46,16 +58,25 @@ cd ..
 git clone https://github.com/root-project/cling.git
 mkdir cling-build && cd cling-build
 cmake -DLLVM_EXTERNAL_PROJECTS=cling -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../cling/ -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" -DCMAKE_BUILD_TYPE=Release ../llvm-project/llvm
-cmake --build . --target cling
+cmake --build . --target clang cling
 ```
 
 See also the instructions [on the webpage](https://root.cern/cling/cling_build_instructions/).
 
 Usage
 -----
-Assuming we're in the build folder:
+Assuming we're in the build folder.
+
+If Cling is built as a standalone project, you need to specify the include directory for headers:
+
 ```bash
-./bin/cling '#include <stdio.h>' 'printf("Hello World!\n")'
+./bin/cling -I"../cling/include" '#include <stdio.h>' 'printf("Hello World!\n");'
+```
+
+If build Cling as part of LLVM:
+
+```bash
+./bin/cling '#include <stdio.h>' 'printf("Hello World!\n");'
 ```
 
 To get started run:


### PR DESCRIPTION
Clarify standalone and LLVM-integrated build methods, along with usage instructions. Improved installation steps to ensure successful execution.

## Build Cling As Standalone Project

Clarifies the distinct build processes for standalone Cling and Cling integrated with LLVM, addressing common user errors related to missing dependencies and incorrect build commands. Standalone Cling's header file locations differ from LLVM-integrated builds, causing potential file not found.

```shell
$ ./bin/cling                   
input_line_2:1:10: fatal error: 'cling/Interpreter/RuntimeUniverse.h' file not found
#include <cling/Interpreter/RuntimeUniverse.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

****************** CLING ******************
* Type C++ code and press enter to run it *
*             Type .q to exit             *
*******************************************
[cling]$ 
```

## Build Cling Along with LLVM

[issue#533](https://github.com/root-project/cling/issues/533), [issue#536](https://github.com/root-project/cling/issues/536), [issue#531](https://github.com/root-project/cling/issues/531) and [issue#543](https://github.com/root-project/cling/issues/543) highlight a common error: building Cling with cmake --build . --target cling within an LLVM source tree fails because it only builds the Cling target, not the necessary Clang dependencies, clang.